### PR TITLE
Null ref causes system UI crash on orientation change.

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -4013,12 +4013,17 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
      * @return True if we should recreate the status bar
      */
     private boolean shouldUpdateStatusbar(ThemeConfig oldTheme, ThemeConfig newTheme) {
-        return newTheme != null && (oldTheme == null || !newTheme.getOverlayForStatusBar()
-                .equals(oldTheme.getOverlayForStatusBar()) ||
-                !newTheme.getFontPkgName()
-                        .equals(oldTheme.getFontPkgName()) ||
-                !newTheme.getIconPackPkgName()
-                        .equals(oldTheme.getIconPackPkgName()) ||
+        // no newTheme, so no need to update status bar
+        if (newTheme == null) return false;
+
+        final String overlay = newTheme.getOverlayForStatusBar();
+        final String icons = newTheme.getIconPackPkgName();
+        final String fonts = newTheme.getFontPkgName();
+
+        return oldTheme == null ||
+                (overlay != null && !overlay.equals(oldTheme.getOverlayForStatusBar()) ||
+                (fonts != null && !fonts.equals(oldTheme.getFontPkgName())) ||
+                (icons != null && !icons.equals(oldTheme.getIconPackPkgName())) ||
                 newTheme.getLastThemeChangeRequestType() == RequestType.THEME_UPDATED);
     }
 


### PR DESCRIPTION
Revert "Revert Themes: Check if newTheme has null fonts, icons, or overlays"

This reverts commit f3cecca28f7a83abe0028d15fbb02bc53e722df7.
