### PR TITLE
Update MetricsConstants.java

### DIFF
--- a/core/java/com/android/internal/logging/MetricsConstants.java
+++ b/core/java/com/android/internal/logging/MetricsConstants.java
@@ -21,7 +21,7 @@ package com.android.internal.logging;
  * @hide
  */
 public interface MetricsConstants {
-     public static final int DONT_TRACK_ME_BRO = -Integer.MAX_VALUE + 1;	
+     
     // These constants must match those in the analytic pipeline, do not edit.
     // Add temporary values to the top of MetricsLogger instead.
     public static final int VIEW_UNKNOWN = 0;


### PR DESCRIPTION
But since it is away ?
http://review.cyanogenmod.org/#/c/127765/2/core/java/com/android/internal/logging/MetricsConstants.java

SystemUi: Nuke DONT_TRACK label, and introduce CMMetricsLogger constants.

Change-Id: I650f1be28f2cf75f0ac15056aa216b5b5ed33a86

http://review.cyanogenmod.org/#/c/127765/
