### PR TITLE
Fix VisualizerTile

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/VisualizerTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/VisualizerTile.java
@@ -122,7 +122,7 @@ public class VisualizerTile extends QSTile<QSTile.BooleanState>  implements Keyg
     public QSTileView createTileView(Context context) {
         return new QSTileView(context) {
             @Override
-            protected View createIcon() {
+            public View createIcon() {
                 Resources r = mContext.getResources();
 
                 boolean mQSCSwitch = Settings.System.getInt(getContext().getContentResolver(),


### PR DESCRIPTION
the subclass has visibility of private for the function but the superclass has visibility public.
Make the subclass's View createIcon() method public. It fixes the below error :

ERROR : frameworks/base/packages/SystemUI/src/com/android/systemui/qs/tiles/VisualizerTile.java:125: Cannot reduce the visibility of the inherited method from QSTileView
