### PR TITLE
Enable\Disable bluetooth battery status[1/2]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -6045,6 +6045,13 @@ public final class Settings {
         public static final String NOTIFICATION_ALPHA = "notification_alpha";
 
         /**
+         * Enable\Disable Bluetooth Battery bar
+         * @hide
+         */
+        public static final String BLUETOOTH_SHOW_BATTERY = "bluetooth_show_battery";
+
+
+        /**
          * Settings to backup. This is here so that it's in the same place as the settings
          * keys and easy to update.
          *

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarPolicy.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarPolicy.java
@@ -101,6 +101,7 @@ public class PhoneStatusBarPolicy implements Callback {
     private final SuController mSuController;
     private boolean mSuIndicatorVisible;
     private int mHeadsetIconVisible;
+    private boolean mShowBluetoothBattery;
 
     // Assume it's all good unless we hear otherwise.  We don't always seem
     // to get broadcasts that it *is* there.
@@ -202,6 +203,12 @@ public class PhoneStatusBarPolicy implements Callback {
         //Update initial tty mode
         updateTTYMode();
 
+        //Bluetooth icon
+        mBTIconObserver.onChange(true);
+        mContext.getContentResolver().registerContentObserver(
+                Settings.System.getUriFor(Settings.System.BLUETOOTH_SHOW_BATTERY),
+                false, mBTIconObserver);
+
         // Alarm clock
         mService.setIcon(SLOT_ALARM_CLOCK, R.drawable.stat_sys_alarm, 0, null);
         mService.setIconVisibility(SLOT_ALARM_CLOCK, false);
@@ -275,6 +282,20 @@ public class PhoneStatusBarPolicy implements Callback {
             if (am1.isWiredHeadsetOn()) {
                 updateHeadset(mHeadsetIntent);
             }
+        }
+
+        @Override
+        public void onChange(boolean selfChange) {
+            onChange(selfChange, null);
+        }
+    };
+
+    private ContentObserver mBTIconObserver = new ContentObserver(null) {
+        @Override
+        public void onChange(boolean selfChange, Uri uri) {
+            mShowBluetoothBattery = Settings.System.getInt(mContext.getContentResolver(),
+                    Settings.System.BLUETOOTH_SHOW_BATTERY, 0) == 1;
+            updateBluetooth();
         }
 
         @Override
@@ -434,9 +455,9 @@ public class PhoneStatusBarPolicy implements Callback {
         if (mBluetooth != null) {
             bluetoothEnabled = mBluetooth.isBluetoothEnabled();
             if (mBluetooth.isBluetoothConnected()) {
-                if (mBluetoothBatteryLevel == null) {
+                if (mBluetoothBatteryLevel == null && !mShowBluetoothBattery) {
                     iconId = R.drawable.stat_sys_data_bluetooth_connected;
-                } else {
+                } else if (mBluetoothBatteryLevel != null && mShowBluetoothBattery) {
                     if (mBluetoothBatteryLevel<=0.15f) {
                         iconId = R.drawable.stat_sys_data_bluetooth_connected_battery_1;
                     } else if (mBluetoothBatteryLevel<=0.375f) {
@@ -458,6 +479,7 @@ public class PhoneStatusBarPolicy implements Callback {
         mService.setIcon(SLOT_BLUETOOTH, iconId, 0, contentDescription);
         mService.setIconVisibility(SLOT_BLUETOOTH, bluetoothEnabled);
     }
+
 
     private final void updateTTY(Intent intent) {
         int currentTtyMode = intent.getIntExtra(TelecomManager.EXTRA_CURRENT_TTY_MODE,


### PR DESCRIPTION
Based on this patch:
http://review.cyanogenmod.org/#/c/153034/
https://github.com/CyanogenMod/android_frameworks_base/commit/88e7a6c7fcaf71d6dae2b9067db19aaeba7de39b

This just makes it configurable for the user, in case they don't want to see that, or if their themes doesn't support the new icons yet.

Signed-off-by: Corey Edwards ensabahnur16@gmail.com

Conflicts:
    packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarPolicy.java
