### PR TITLE
Remove the unnecessary window animation request

### DIFF
--- a/services/core/java/com/android/server/display/ColorFade.java
+++ b/services/core/java/com/android/server/display/ColorFade.java
@@ -36,6 +36,7 @@ import android.opengl.EGLDisplay;
 import android.opengl.EGLSurface;
 import android.opengl.GLES20;
 import android.opengl.GLES11Ext;
+import android.os.SystemProperties;
 import android.util.Slog;
 import android.view.DisplayInfo;
 import android.view.Surface.OutOfResourcesException;
@@ -69,6 +70,9 @@ final class ColorFade {
     // be ready to run smoothly.  We use 3 frames because we are triple-buffered.
     // See code for details.
     private static final int DEJANK_FRAMES = 3;
+
+    private static final boolean DESTROY_SURFACE_AFTER_DETACH =
+            SystemProperties.getBoolean("ro.egl.destroy_after_detach", false);
 
     private final int mDisplayId;
 
@@ -331,9 +335,14 @@ final class ColorFade {
                 destroyScreenshotTexture();
                 destroyGLShaders();
                 destroyGLBuffers();
-                destroyEglSurface();
+                if (!DESTROY_SURFACE_AFTER_DETACH) {
+                    destroyEglSurface();
+                }
             } finally {
                 detachEglContext();
+            }
+            if (DESTROY_SURFACE_AFTER_DETACH) {
+                destroyEglSurface();
             }
             // This is being called with no active context so shouldn't be
             // needed but is safer to not change for now.

--- a/services/core/java/com/android/server/wm/WindowAnimator.java
+++ b/services/core/java/com/android/server/wm/WindowAnimator.java
@@ -578,7 +578,7 @@ public class WindowAnimator {
             // If this window is animating, make a note that we have
             // an animating window and take care of a request to run
             // a detached wallpaper animation.
-            if (winAnimator.mAnimating) {
+            if (winAnimator.mAnimating && !winAnimator.isDummyAnimation()) {
                 if (winAnimator.mAnimation != null) {
                     if ((flags & FLAG_SHOW_WALLPAPER) != 0
                             && winAnimator.mAnimation.getDetachWallpaper()) {


### PR DESCRIPTION
When AppWindowAnimator set with dummy animation, there is no need to
request window animation

When the device's performance is low (CPU run with one Core and in low frequency),
the dummy animation may hold the WMS synchornized lock cycling,
it will drag down the performance

Change-Id: I4845af9001d630984a1fd06499b28ace7db2ea63