### PR TITLE
base: add BootReceiver back need by cpu overlay start at boot

### DIFF
--- a/packages/SystemUI/AndroidManifest.xml
+++ b/packages/SystemUI/AndroidManifest.xml
@@ -254,6 +254,12 @@
         <service android:name=".CPUInfoService"
                 android:exported="true" />
 
+        <receiver android:name=".BootReceiver" androidprv:systemUserOnly="true">
+            <intent-filter android:priority="1000">
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+       </receiver>
+
         <service android:name=".ImageWallpaper"
                 android:permission="android.permission.BIND_WALLPAPER"
                 android:exported="true" />

--- a/packages/SystemUI/src/com/android/systemui/BootReceiver.java
+++ b/packages/SystemUI/src/com/android/systemui/BootReceiver.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2011 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.systemui;
+
+import android.content.BroadcastReceiver;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.Intent;
+import android.provider.Settings;
+import android.util.Log;
+
+/**
+ * Performs a number of miscellaneous, non-system-critical actions
+ * after the system has finished booting.
+ */
+public class BootReceiver extends BroadcastReceiver {
+    private static final String TAG = "SystemUIBootReceiver";
+
+    @Override
+    public void onReceive(final Context context, Intent intent) {
+        try {
+            // Start the cpu info overlay, if activated
+            ContentResolver res = context.getContentResolver();
+            if (Settings.Global.getInt(res, Settings.Global.SHOW_CPU, 0) != 0) {
+                Intent cpuinfo = new Intent(context, com.android.systemui.CPUInfoService.class);
+                context.startService(cpuinfo);
+            }
+
+        } catch (Exception e) {
+            Log.e(TAG, "Can't start cpuinfo service", e);
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Felipe Leon <fglfgl27@gmail.com>

I tested before this no cpu info after boot even the switch was on, after this commit all good.
Was remove on the latest 7.1.1 update because LoadAverageService is not used anymore.