### PR TITLE
QS: Classic GPS Tile

### DIFF
--- a/packages/SystemUI/res/values/config.xml
+++ b/packages/SystemUI/res/values/config.xml
@@ -108,7 +108,7 @@
      </string>
 
     <!-- Tiles native to System UI. Order should match "quick_settings_tiles_default" -->
-    <string name="quick_settings_tiles_stock" translatable="false">      wifi,cell,battery,dnd,flashlight,rotation,bt,airplane,location,hotspot,inversion,saver,work,cast,screenshot,sound,volume,adb_network,sync,app_picker,heads_up,reboot,usb_tether,music,ime,configurations,caffeine,lte,nfc,screenrecord,expanded_desktop,navigation_bar,app_side_bar,app_circle_bar,pie,gesture_anywhere,pulse,ambient_display
+    <string name="quick_settings_tiles_stock" translatable="false">      wifi,cell,battery,dnd,flashlight,rotation,bt,airplane,location,gps,hotspot,inversion,saver,work,cast,screenshot,sound,volume,adb_network,sync,app_picker,heads_up,reboot,usb_tether,music,ime,configurations,caffeine,lte,nfc,screenrecord,expanded_desktop,navigation_bar,app_side_bar,app_circle_bar,pie,gesture_anywhere,pulse,ambient_display
     </string>
 
     <!-- The tiles to display in QuickSettings -->

--- a/packages/SystemUI/res/values/rr_strings.xml
+++ b/packages/SystemUI/res/values/rr_strings.xml
@@ -140,6 +140,11 @@
     <string name="accessibility_quick_settings_heads_up_on">Heads up on.</string>
     <string name="accessibility_quick_settings_heads_up_changed_off">Heads up turned off.</string>
     <string name="accessibility_quick_settings_heads_up_changed_on">Heads up turned on.</string>
+    <string name="quick_settings_gps_label">GPS</string>
+    <string name="accessibility_quick_settings_gps_off">GPS off.</string>
+    <string name="accessibility_quick_settings_gps_on">GPS on.</string>
+    <string name="accessibility_quick_settings_gps_changed_off">GPS turned off.</string>
+    <string name="accessibility_quick_settings_gps_changed_on">GPS turned on.</string>
 
         <!-- PA Pie controls -->
     <string name="pie_date_format" translatable="false">ccc, dd MMM yyyy</string>

--- a/packages/SystemUI/src/com/android/systemui/SystemUIFactory.java
+++ b/packages/SystemUI/src/com/android/systemui/SystemUIFactory.java
@@ -43,6 +43,7 @@ import com.android.systemui.statusbar.policy.FlashlightController;
 import com.android.systemui.statusbar.policy.HotspotController;
 import com.android.systemui.statusbar.policy.KeyguardMonitor;
 import com.android.systemui.statusbar.policy.LocationController;
+import com.android.systemui.statusbar.policy.GpsController;
 import com.android.systemui.statusbar.policy.NetworkController;
 import com.android.systemui.statusbar.policy.NextAlarmController;
 import com.android.systemui.statusbar.policy.RotationLockController;
@@ -104,14 +105,14 @@ public class SystemUIFactory {
 
     public QSTileHost createQSTileHost(Context context, PhoneStatusBar statusBar,
             BluetoothController bluetooth, LocationController location,
-            RotationLockController rotation, NetworkController network,
+            GpsController gps,  RotationLockController rotation, NetworkController network,
             ZenModeController zen, HotspotController hotspot,
             CastController cast, FlashlightController flashlight,
             UserSwitcherController userSwitcher, UserInfoController userInfo,
             KeyguardMonitor keyguard, SecurityController security,
             BatteryController battery, StatusBarIconController iconController,
             NextAlarmController nextAlarmController) {
-        return new QSTileHost(context, statusBar, bluetooth, location, rotation, network, zen,
+        return new QSTileHost(context, statusBar, bluetooth, location, gps, rotation, network, zen,
                 hotspot, cast, flashlight, userSwitcher, userInfo, keyguard, security, battery,
                 iconController, nextAlarmController);
     }

--- a/packages/SystemUI/src/com/android/systemui/qs/QSTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/QSTile.java
@@ -44,6 +44,7 @@ import com.android.systemui.statusbar.policy.HotspotController;
 import com.android.systemui.statusbar.policy.KeyguardMonitor;
 import com.android.systemui.statusbar.policy.Listenable;
 import com.android.systemui.statusbar.policy.LocationController;
+import com.android.systemui.statusbar.policy.GpsController;
 import com.android.systemui.statusbar.policy.NetworkController;
 import com.android.systemui.statusbar.policy.RotationLockController;
 import com.android.systemui.statusbar.policy.UserInfoController;
@@ -438,6 +439,7 @@ public abstract class QSTile<TState extends State> {
         void removeCallback(Callback callback);
         BluetoothController getBluetoothController();
         LocationController getLocationController();
+        GpsController getGpsController();
         RotationLockController getRotationLockController();
         NetworkController getNetworkController();
         ZenModeController getZenModeController();

--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/GpsTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/GpsTile.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2016 RR
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.systemui.qs.tiles;
+
+
+import android.content.Intent;
+import android.os.UserManager;
+
+import android.provider.Settings;
+import android.widget.Switch;
+
+import com.android.internal.logging.MetricsProto.MetricsEvent;
+import com.android.systemui.R;
+import com.android.systemui.qs.QSTile;
+import com.android.systemui.statusbar.policy.KeyguardMonitor;
+import com.android.systemui.statusbar.policy.GpsController;
+import com.android.systemui.statusbar.policy.GpsController.GpsSettingsChangeCallback;
+
+/** Quick settings tile: Gps **/
+public class GpsTile extends QSTile<QSTile.BooleanState> {
+
+    private final AnimationIcon mEnable =
+        new AnimationIcon(R.drawable.ic_signal_location_enable_animation,
+            R.drawable.ic_signal_location_disable);
+    private final AnimationIcon mDisable =
+        new AnimationIcon(R.drawable.ic_signal_location_disable_animation,
+            R.drawable.ic_signal_location_enable);
+
+    private final GpsController mController;
+    private final KeyguardMonitor mKeyguard;
+    private final Callback mCallback = new Callback();
+
+    public GpsTile(Host host) {
+        super(host);
+        mController = host.getGpsController();
+        mKeyguard = host.getKeyguardMonitor();
+    }
+
+    @Override
+    public BooleanState newTileState() {
+        return new BooleanState();
+    }
+
+    @Override
+    public void setListening(boolean listening) {
+        if (listening) {
+            mController.addSettingsChangedCallback(mCallback);
+            mKeyguard.addCallback(mCallback);
+        } else {
+            mController.removeSettingsChangedCallback(mCallback);
+            mKeyguard.removeCallback(mCallback);
+        }
+    }
+
+    @Override
+    public Intent getLongClickIntent() {
+        return new Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS);
+    }
+
+    @Override
+    protected void handleClick() {
+        if (mKeyguard.isSecure() && mKeyguard.isShowing()) {
+            mHost.startRunnableDismissingKeyguard(new Runnable() {
+                @Override
+                public void run() {
+                    mHost.openPanels();
+                    mController.setGpsEnabled(!mController.isGpsEnabled());
+                }
+            });
+
+            return;
+        }
+
+        mController.setGpsEnabled(!mController.isGpsEnabled());
+    }
+
+    @Override
+    public CharSequence getTileLabel() {
+        return mContext.getString(R.string.quick_settings_gps_label);
+    }
+
+    @Override
+    protected void handleUpdateState(BooleanState state, Object arg) {
+        final boolean gpsEnabled = mController.isGpsEnabled();
+
+        // Work around for bug 15916487: don't show location tile on top of lock screen. After the
+        // bug is fixed, this should be reverted to only hiding it on secure lock screens:
+        // state.visible = !(mKeyguard.isSecure() && mKeyguard.isShowing());
+        state.value = gpsEnabled;
+        checkIfRestrictionEnforcedByAdminOnly(state, UserManager.DISALLOW_SHARE_LOCATION);
+
+        state.label = mContext.getString(R.string.quick_settings_gps_label);
+
+        if (gpsEnabled) {
+            state.contentDescription = mContext.getString(R.string.accessibility_quick_settings_gps_on);
+            state.icon = mEnable;
+        } else {
+            state.contentDescription = mContext.getString(R.string.accessibility_quick_settings_gps_off);
+            state.icon = mDisable;
+        }
+
+        state.minimalAccessibilityClassName = state.expandedAccessibilityClassName
+            = Switch.class.getName();
+    }
+
+    @Override
+    public int getMetricsCategory() {
+        return MetricsEvent.QS_LOCATION;
+    }
+
+    @Override
+    protected String composeChangeAnnouncement() {
+        if (mState.value) {
+            return mContext.getString(R.string.accessibility_quick_settings_gps_changed_on);
+        } else {
+            return mContext.getString(R.string.accessibility_quick_settings_gps_changed_off);
+        }
+    }
+
+    private final class Callback implements GpsSettingsChangeCallback, KeyguardMonitor.Callback {
+        @Override
+        public void onGpsSettingsChanged(boolean enabled) {
+            refreshState();
+        }
+
+        @Override
+        public void onKeyguardChanged() {
+            refreshState();
+        }
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -214,6 +214,7 @@ import com.android.systemui.statusbar.policy.HotspotControllerImpl;
 import com.android.systemui.statusbar.policy.KeyguardMonitor;
 import com.android.systemui.statusbar.policy.KeyguardUserSwitcher;
 import com.android.systemui.statusbar.policy.LocationControllerImpl;
+import com.android.systemui.statusbar.policy.GpsControllerImpl;
 import com.android.systemui.statusbar.policy.NetworkController;
 import com.android.systemui.statusbar.policy.NetworkControllerImpl;
 import com.android.systemui.statusbar.policy.NextAlarmController;
@@ -390,6 +391,7 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
     SecurityControllerImpl mSecurityController;
     protected BatteryController mBatteryController;
     LocationControllerImpl mLocationController;
+    GpsControllerImpl mGpsController;
     NetworkControllerImpl mNetworkController;
     HotspotControllerImpl mHotspotController;
     RotationLockControllerImpl mRotationLockController;
@@ -1475,6 +1477,8 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
         // Other icons
         mLocationController = new LocationControllerImpl(mContext,
                 mHandlerThread.getLooper()); // will post a notification
+        mGpsController = new GpsControllerImpl(mContext,
+                mHandlerThread.getLooper());
         mBatteryController = createBatteryController();
         mBatteryController.addStateChangedCallback(new BatteryStateChangeCallback() {
             @Override
@@ -1557,7 +1561,7 @@ mWeatherTempSize, mWeatherTempFontStyle, mWeatherTempColor);
                 R.id.qs_auto_reinflate_container);
         if (container != null) {
             final QSTileHost qsh = SystemUIFactory.getInstance().createQSTileHost(mContext, this,
-                    mBluetoothController, mLocationController, mRotationLockController,
+                    mBluetoothController, mLocationController, mGpsController, mRotationLockController,
                     mNetworkController, mZenModeController, mHotspotController,
                     mCastController, mFlashlightController,
                     mUserSwitcherController, mUserInfoController, mKeyguardMonitor,

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/QSTileHost.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/QSTileHost.java
@@ -52,6 +52,7 @@ import com.android.systemui.qs.tiles.ColorInversionTile;
 import com.android.systemui.qs.tiles.DataSaverTile;
 import com.android.systemui.qs.tiles.DndTile;
 import com.android.systemui.qs.tiles.ExpandedDesktopTile;
+import com.android.systemui.qs.tiles.GpsTile;
 import com.android.systemui.qs.tiles.PieTile;
 import com.android.systemui.qs.tiles.ScreenrecordTile;
 import com.android.systemui.qs.tiles.NfcTile;
@@ -83,6 +84,7 @@ import com.android.systemui.qs.tiles.WorkModeTile;
 import com.android.systemui.statusbar.policy.BatteryController;
 import com.android.systemui.statusbar.policy.BluetoothController;
 import com.android.systemui.statusbar.policy.CastController;
+import com.android.systemui.statusbar.policy.GpsController;
 import com.android.systemui.statusbar.policy.NextAlarmController;
 import com.android.systemui.statusbar.policy.FlashlightController;
 import com.android.systemui.statusbar.policy.HotspotController;
@@ -120,6 +122,7 @@ public class QSTileHost implements QSTile.Host, Tunable {
     protected final ArrayList<String> mTileSpecs = new ArrayList<>();
     private final BluetoothController mBluetooth;
     private final LocationController mLocation;
+    private final GpsController mGps;
     private final RotationLockController mRotation;
     private final NetworkController mNetwork;
     private final ZenModeController mZen;
@@ -144,7 +147,7 @@ public class QSTileHost implements QSTile.Host, Tunable {
 
     public QSTileHost(Context context, PhoneStatusBar statusBar,
             BluetoothController bluetooth, LocationController location,
-            RotationLockController rotation, NetworkController network,
+            GpsController gps, RotationLockController rotation, NetworkController network,
             ZenModeController zen, HotspotController hotspot,
             CastController cast, FlashlightController flashlight,
             UserSwitcherController userSwitcher, UserInfoController userInfo,
@@ -155,6 +158,7 @@ public class QSTileHost implements QSTile.Host, Tunable {
         mStatusBar = statusBar;
         mBluetooth = bluetooth;
         mLocation = location;
+        mGps = gps;
         mRotation = rotation;
         mNetwork = network;
         mZen = zen;
@@ -283,6 +287,9 @@ public class QSTileHost implements QSTile.Host, Tunable {
     public LocationController getLocationController() {
         return mLocation;
     }
+
+    @Override
+    public GpsController getGpsController() { return mGps; }
 
     @Override
     public RotationLockController getRotationLockController() {
@@ -468,6 +475,7 @@ public class QSTileHost implements QSTile.Host, Tunable {
         else if (tileSpec.equals("rotation")) return new RotationLockTile(this);
         else if (tileSpec.equals("flashlight")) return new FlashlightTile(this);
         else if (tileSpec.equals("location")) return new LocationTile(this);
+        else if (tileSpec.equals("gps")) return new GpsTile(this);
         else if (tileSpec.equals("cast")) return new CastTile(this);
         else if (tileSpec.equals("hotspot")) return new HotspotTile(this);
         else if (tileSpec.equals("user")) return new UserTile(this);

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/GpsController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/GpsController.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2016 RR
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.systemui.statusbar.policy;
+
+public interface GpsController {
+    boolean isGpsEnabled();
+    boolean setGpsEnabled(boolean enabled);
+    void addSettingsChangedCallback(GpsSettingsChangeCallback cb);
+    void removeSettingsChangedCallback(GpsSettingsChangeCallback cb);
+
+    /**
+     * A callback for change in gps settings (the user has enabled/disabled gps).
+     */
+    public interface GpsSettingsChangeCallback {
+        /**
+         * Called whenever location settings change.
+         *
+         * @param gpsEnabled A value of true indicates that location mode is either high accuracy or sensors only
+         *                   in settings.
+         */
+        void onGpsSettingsChanged(boolean gpsEnabled);
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/GpsControllerImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/GpsControllerImpl.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (C) 2016 RR
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.systemui.statusbar.policy;
+
+import android.app.ActivityManager;
+import android.app.AppOpsManager;
+import android.app.StatusBarManager;
+import android.content.BroadcastReceiver;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.location.LocationManager;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.Message;
+import android.os.UserHandle;
+import android.os.UserManager;
+import android.provider.Settings;
+import com.android.systemui.R;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A controller to manage changes of gps and update the views accordingly.
+ */
+public class GpsControllerImpl extends BroadcastReceiver implements GpsController {
+    public static final int LOCATION_STATUS_ICON_ID = R.drawable.stat_sys_location;
+
+    private static final int[] mHighPowerRequestAppOpArray =
+        new int[] { AppOpsManager.OP_MONITOR_HIGH_POWER_LOCATION};
+
+    private Context mContext;
+
+    private AppOpsManager mAppOpsManager;
+    private StatusBarManager mStatusBarManager;
+
+    private boolean mAreActiveLocationRequests;
+
+    private ArrayList<GpsSettingsChangeCallback> mSettingsChangeCallbacks =
+        new ArrayList<GpsSettingsChangeCallback>();
+    private final H mHandler = new H();
+    public final String mSlotLocation;
+
+    public GpsControllerImpl(Context context, Looper bgLooper) {
+        mContext = context;
+        mSlotLocation = mContext.getString(com.android.internal.R.string.status_bar_location);
+
+        // Register to listen for changes in location settings
+        IntentFilter filter = new IntentFilter();
+        filter.addAction(LocationManager.HIGH_POWER_REQUEST_CHANGE_ACTION);
+        filter.addAction(LocationManager.MODE_CHANGED_ACTION);
+        context.registerReceiverAsUser(this, UserHandle.ALL, filter, null, new Handler(bgLooper));
+
+        mAppOpsManager = (AppOpsManager) context.getSystemService(Context.APP_OPS_SERVICE);
+        mStatusBarManager = (StatusBarManager) context.getSystemService(Context.STATUS_BAR_SERVICE);
+
+        // Examine the current location state and initialize the status view.
+        updateActiveLocationRequests();
+        refreshViews();
+    }
+
+    /**
+     * Add a callback to listen for changes in gps settings
+     */
+    public void addSettingsChangedCallback(GpsSettingsChangeCallback callback) {
+        mSettingsChangeCallbacks.add(callback);
+        mHandler.sendEmptyMessage(H.MSG_GPS_SETTINGS_CHANGED);
+    }
+
+    public void removeSettingsChangedCallback(GpsSettingsChangeCallback callback) {
+        mSettingsChangeCallbacks.remove(callback);
+    }
+
+    public boolean isNetworkLocationEnabled() {
+        ContentResolver resolver = mContext.getContentResolver();
+        
+        // QuickSettings always runs as the owner, so specifically retrieve the settings
+        // for the current foregound user.
+        int mode = Settings.Secure.getIntForUser(resolver, Settings.Secure.LOCATION_MODE,
+            Settings.Secure.LOCATION_MODE_OFF, ActivityManager.getCurrentUser());
+        
+        return mode ==
+            Settings.Secure.LOCATION_MODE_BATTERY_SAVING || mode == Settings.Secure.LOCATION_MODE_HIGH_ACCURACY;
+    }
+    
+    /**
+     * 
+     * @return true if gps is enabled
+     */
+    public boolean isGpsEnabled() {
+        ContentResolver resolver = mContext.getContentResolver();
+        
+        // QuickSettings always runs as the owner, so specifically retrieve the settings
+        // for the current foreground user.
+        int mode = Settings.Secure.getIntForUser(resolver, Settings.Secure.LOCATION_MODE,
+            Settings.Secure.LOCATION_MODE_OFF, ActivityManager.getCurrentUser());
+        
+        return mode ==
+            Settings.Secure.LOCATION_MODE_SENSORS_ONLY || mode == Settings.Secure.LOCATION_MODE_HIGH_ACCURACY;
+    }
+
+    /**
+     * Enable or disable gps
+     * @return true if attempt to change setting was successful
+     */
+    public boolean setGpsEnabled(boolean enabled) {
+        int currentUserId = ActivityManager.getCurrentUser();
+        if (isUserLocationRestricted(currentUserId)) {
+            return false;
+        }
+        final ContentResolver contentResolver = mContext.getContentResolver();
+
+        int mode;
+
+        if (isNetworkLocationEnabled()) {
+            mode = enabled
+                ? Settings.Secure.LOCATION_MODE_HIGH_ACCURACY : Settings.Secure.LOCATION_MODE_BATTERY_SAVING;
+        } else {
+            mode = enabled
+                ? Settings.Secure.LOCATION_MODE_SENSORS_ONLY : Settings.Secure.LOCATION_MODE_OFF;
+        }
+
+        // QuickSettings always runs as the owner, so specifically set the settings
+        // for the current foreground user.
+        return Settings.Secure
+            .putIntForUser(contentResolver, Settings.Secure.LOCATION_MODE, mode, currentUserId);
+    }
+
+    /**
+     * Returns true if the current user is restricted from using location.
+     */
+    private boolean isUserLocationRestricted(int userId) {
+        final UserManager userManager = (UserManager) mContext.getSystemService(Context.USER_SERVICE);
+        return userManager.hasUserRestriction(
+            UserManager.DISALLOW_SHARE_LOCATION,
+            new UserHandle(userId));
+    }
+
+    /**
+     * Returns true if there currently exist active high power location requests.
+     */
+    private boolean areActiveHighPowerLocationRequests() {
+        List<AppOpsManager.PackageOps> packages
+            = mAppOpsManager.getPackagesForOps(mHighPowerRequestAppOpArray);
+        // AppOpsManager can return null when there is no requested data.
+        if (packages != null) {
+            final int numPackages = packages.size();
+            for (int packageInd = 0; packageInd < numPackages; packageInd++) {
+                AppOpsManager.PackageOps packageOp = packages.get(packageInd);
+                List<AppOpsManager.OpEntry> opEntries = packageOp.getOps();
+                if (opEntries != null) {
+                    final int numOps = opEntries.size();
+                    for (int opInd = 0; opInd < numOps; opInd++) {
+                        AppOpsManager.OpEntry opEntry = opEntries.get(opInd);
+                        // AppOpsManager should only return OP_MONITOR_HIGH_POWER_LOCATION because
+                        // of the mHighPowerRequestAppOpArray filter, but checking defensively.
+                        if (opEntry.getOp() == AppOpsManager.OP_MONITOR_HIGH_POWER_LOCATION) {
+                            if (opEntry.isRunning()) {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+    
+    private void updateActiveLocationRequests() {
+        boolean hadActiveLocationRequests = mAreActiveLocationRequests;
+        mAreActiveLocationRequests = areActiveHighPowerLocationRequests();
+        if (mAreActiveLocationRequests != hadActiveLocationRequests) {
+            refreshViews();
+        }
+    }
+
+    /**
+     * Updates the status view based on the current state of location requests.
+     */
+    private void refreshViews() {
+        if (mAreActiveLocationRequests) {
+            mStatusBarManager.setIcon(mSlotLocation, LOCATION_STATUS_ICON_ID,
+                0, mContext.getString(R.string.accessibility_location_active));
+        } else {
+            mStatusBarManager.removeIcon(mSlotLocation);
+        }
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        final String action = intent.getAction();
+
+        if (LocationManager.HIGH_POWER_REQUEST_CHANGE_ACTION.equals(action)) {
+            updateActiveLocationRequests();
+        } else if (LocationManager.MODE_CHANGED_ACTION.equals(action)) {
+            mHandler.sendEmptyMessage(H.MSG_GPS_SETTINGS_CHANGED);
+        }
+    }
+
+    private final class H extends Handler {
+        private static final int MSG_GPS_SETTINGS_CHANGED = 1;
+
+        @Override
+        public void handleMessage(Message msg) {
+            switch (msg.what) {
+                case MSG_GPS_SETTINGS_CHANGED:
+                    gpsSettingsChanged();
+                    break;
+            }
+        }
+
+        private void gpsSettingsChanged() {
+            boolean isEnabled = isGpsEnabled();
+            for (GpsSettingsChangeCallback callback : mSettingsChangeCallbacks) {
+                callback.onGpsSettingsChanged(isEnabled);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit adds a classic GPS QS tile to control only the GPS state,
regardless network location settings.