### PR TITLE
[PATCH] telephony: Add state check for LteOnCdma to isGsm and isCdma

### DIFF
--- a/telephony/java/android/telephony/ServiceState.java
+++ b/telephony/java/android/telephony/ServiceState.java
@@ -20,6 +20,7 @@ import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.telephony.Rlog;
+import com.android.internal.telephony.PhoneConstants;
 
 /**
  * Contains phone state and service related information.
@@ -1176,12 +1177,11 @@ public class ServiceState implements Parcelable {
                 || radioTechnology == RIL_RADIO_TECHNOLOGY_HSDPA
                 || radioTechnology == RIL_RADIO_TECHNOLOGY_HSUPA
                 || radioTechnology == RIL_RADIO_TECHNOLOGY_HSPA
-                || radioTechnology == RIL_RADIO_TECHNOLOGY_LTE
                 || radioTechnology == RIL_RADIO_TECHNOLOGY_HSPAP
                 || radioTechnology == RIL_RADIO_TECHNOLOGY_GSM
                 || radioTechnology == RIL_RADIO_TECHNOLOGY_TD_SCDMA
                 || radioTechnology == RIL_RADIO_TECHNOLOGY_IWLAN
-                || radioTechnology == RIL_RADIO_TECHNOLOGY_LTE_CA;
+                || (isLte(radioTechnology) && !isLteOnCdma(radioTechnology));
 
     }
 
@@ -1193,9 +1193,16 @@ public class ServiceState implements Parcelable {
                 || radioTechnology == RIL_RADIO_TECHNOLOGY_EVDO_0
                 || radioTechnology == RIL_RADIO_TECHNOLOGY_EVDO_A
                 || radioTechnology == RIL_RADIO_TECHNOLOGY_EVDO_B
-                || radioTechnology == RIL_RADIO_TECHNOLOGY_EHRPD;
+                || radioTechnology == RIL_RADIO_TECHNOLOGY_EHRPD
+                || isLteOnCdma(radioTechnology);
     }
 
+    /** @hide */
+    private static boolean isLteOnCdma(int radioTechnology) {
+        return isLte(radioTechnology)
+             && TelephonyManager.getLteOnCdmaModeStatic() == PhoneConstants.LTE_ON_CDMA_TRUE;
+    }
+    
     /** @hide */
     public static boolean isLte(int radioTechnology) {
         return radioTechnology == RIL_RADIO_TECHNOLOGY_LTE ||


### PR DESCRIPTION
From: Seth Shelnutt <Shelnutt2@gmail.com>
Date: Tue, 13 Dec 2016 13:53:01 -0500
https://github.com/CyanogenMod/android_frameworks_base/commit/039a09e48cf1edc4fb004383354345eadbc6d72a.patch
[PATCH] telephony: Add state check for LteOnCdma to isGsm and isCdma

If a cdma phone has LTE it should not report the LTE as GSM if LteOnCdma
is set. This solves an issue with CDMA devices which bounce between GSM
and CDMA phone state when on LTE.