### PR TITLE
Fix wrong peek height of the notification panel

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/stack/NotificationStackScrollLayout.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/stack/NotificationStackScrollLayout.java
@@ -769,7 +769,7 @@ public class NotificationStackScrollLayout extends ViewGroup
 
     public int getFirstItemMinHeight() {
         final ExpandableView firstChild = getFirstChildNotGone();
-        return firstChild != null ? firstChild.getMinHeight() : mCollapsedSize;
+        return firstChild != null ? firstChild.getIntrinsicHeight() : mCollapsedSize;
     }
 
     public int getBottomStackPeekSize() {
@@ -2198,10 +2198,7 @@ public class NotificationStackScrollLayout extends ViewGroup
     }
 
     public int getPeekHeight() {
-        final ExpandableView firstChild = getFirstChildNotGone();
-        final int firstChildMinHeight = firstChild != null ? firstChild.getCollapsedHeight()
-                : mCollapsedSize;
-        return mIntrinsicPadding + firstChildMinHeight + mBottomStackPeekSize
+        return mIntrinsicPadding + getFirstItemMinHeight() + mBottomStackPeekSize
                 + mBottomStackSlowDownHeight;
     }
 


### PR DESCRIPTION
From N, the topmost notification slides in expanded from the top, not collapsed.
(https://android.googlesource.com/platform/frameworks/base/+/d1ad9ab3121cb54387c5d2b71b48708dcaed5c43)
But when peek from status bar, the peek height was measured with collapsed height.
Therefore fix the peek height with expanded height of the topmost notification.

Test: manual - Test peeking from status bar with expandable topmost notification.
Change-Id: I46173c9e82a1221b543133c38ec6aaf746244011
Signed-off-by: mydongistiny <jaysonedson@gmail.com>
Signed-off-by: Pafcholini <nadyaivanova14@gmail.com>