### PR TITLE
telephony: Add state check for LteOnCdma to isGsm and isCdma

### DIFF
--- a/telephony/java/android/telephony/ServiceState.java
+++ b/telephony/java/android/telephony/ServiceState.java
@@ -21,6 +21,8 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.telephony.Rlog;
 
+import com.android.internal.telephony.PhoneConstants;
+
 /**
  * Contains phone state and service related information.
  *
@@ -1176,12 +1178,11 @@ public class ServiceState implements Parcelable {
                 || radioTechnology == RIL_RADIO_TECHNOLOGY_HSDPA
                 || radioTechnology == RIL_RADIO_TECHNOLOGY_HSUPA
                 || radioTechnology == RIL_RADIO_TECHNOLOGY_HSPA
-                || radioTechnology == RIL_RADIO_TECHNOLOGY_LTE
                 || radioTechnology == RIL_RADIO_TECHNOLOGY_HSPAP
                 || radioTechnology == RIL_RADIO_TECHNOLOGY_GSM
                 || radioTechnology == RIL_RADIO_TECHNOLOGY_TD_SCDMA
                 || radioTechnology == RIL_RADIO_TECHNOLOGY_IWLAN
-                || radioTechnology == RIL_RADIO_TECHNOLOGY_LTE_CA;
+                || (isLte(radioTechnology) && !isLteOnCdma(radioTechnology));
 
     }
 
@@ -1193,13 +1194,20 @@ public class ServiceState implements Parcelable {
                 || radioTechnology == RIL_RADIO_TECHNOLOGY_EVDO_0
                 || radioTechnology == RIL_RADIO_TECHNOLOGY_EVDO_A
                 || radioTechnology == RIL_RADIO_TECHNOLOGY_EVDO_B
-                || radioTechnology == RIL_RADIO_TECHNOLOGY_EHRPD;
+                || radioTechnology == RIL_RADIO_TECHNOLOGY_EHRPD
+                || isLteOnCdma(radioTechnology);
     }
 
     /** @hide */
     public static boolean isLte(int radioTechnology) {
         return radioTechnology == RIL_RADIO_TECHNOLOGY_LTE ||
                 radioTechnology == RIL_RADIO_TECHNOLOGY_LTE_CA;
+    }
+
+    /** @hide */
+    private static boolean isLteOnCdma(int radioTechnology) {
+        return isLte(radioTechnology)
+            && TelephonyManager.getLteOnCdmaModeStatic() == PhoneConstants.LTE_ON_CDMA_TRUE;
     }
 
     /** @hide */


### PR DESCRIPTION
If a cdma phone has LTE it should not report the LTE as GSM if LteOnCdma
is set. This solves an issue with CDMA devices which bounce between GSM
and CDMA phone state when on LTE.

Change-Id: I13e14fe69a6a04452f95f937ed5c9f69f46ef8d6

Signed-off-by: Jcfunk <jncorrea1980@gmail.com>