### PR TITLE
Fix TaskManager Running services [1/2]

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/QuickStatusBarHeader.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/QuickStatusBarHeader.java
@@ -502,7 +502,7 @@ public class QuickStatusBarHeader extends BaseStatusBarHeader implements
     public void starttmactivity() {
         Intent intent = new Intent(Intent.ACTION_MAIN);
         intent.setClassName("com.android.settings",
-            "com.android.settings.Settings$RunningServicesActivity");
+            "com.android.settings.Settings$DevRunningServicesActivity");
         mActivityStarter.startActivity(intent, true /* dismissShade */);
     }
 


### PR DESCRIPTION
Instead of RunningServicesActivity, we now fetch from DevRunningServicesActivity

Picked up from https://github.com/AICP/frameworks_base/commit/6b61713a192601a1475da1432a5e9fd05e64443e
Credits: @ezio84 for the original piece of code.

[2/2] is in Settings.

Change-Id: I2f3ce15feb6d24aab777feb6596ccbcd17e39c1c
Signed-off-by: Ashok Soni <ashok.soni@gmail.com>