### PR TITLE
camera: Make secondary camera package list opt out

### DIFF
--- a/core/java/android/hardware/Camera.java
+++ b/core/java/android/hardware/Camera.java
@@ -248,18 +248,18 @@ public class Camera {
      * Returns the number of physical cameras available on this device.
      */
     public static int getNumberOfCameras() {
-        boolean exposeAuxCamera = false;
+        boolean exposeAuxCamera = true;
         String packageName = ActivityThread.currentOpPackageName();
-        /* Force to expose only two cameras
-         * if the package name does not falls in this bucket
+        /* Force exposing only two cameras
+         * if the package name falls in this bucket
          */
-        String packageList = SystemProperties.get("camera.aux.packagelist");
+        String packageList = SystemProperties.get("camera.auxdisable.packagelist");
         if (packageList.length() > 0) {
             TextUtils.StringSplitter splitter = new TextUtils.SimpleStringSplitter(',');
             splitter.setString(packageList);
             for (String str : splitter) {
                 if (packageName.equals(str)) {
-                    exposeAuxCamera = true;
+                    exposeAuxCamera = false;
                     break;
                 }
             }

--- a/core/java/android/hardware/camera2/CameraManager.java
+++ b/core/java/android/hardware/camera2/CameraManager.java
@@ -692,18 +692,18 @@ public final class CameraManager {
 
             try {
                 numCameras = cameraService.getNumberOfCameras(CAMERA_TYPE_ALL);
-                /* Force to expose only two cameras
-                 * if the package name does not falls in this bucket
+                /* Force exposing only two cameras
+                 * if the package name falls in this bucket
                  */
-                boolean exposeAuxCamera = false;
+                boolean exposeAuxCamera = true;
                 String packageName = ActivityThread.currentOpPackageName();
-                String packageList = SystemProperties.get("camera.aux.packagelist");
+                String packageList = SystemProperties.get("camera.auxdisable.packagelist");
                 if (packageList.length() > 0) {
                     TextUtils.StringSplitter splitter = new TextUtils.SimpleStringSplitter(',');
                     splitter.setString(packageList);
                     for (String str : splitter) {
                         if (packageName.equals(str)) {
-                            exposeAuxCamera = true;
+                            exposeAuxCamera = false;
                             break;
                         }
                     }
@@ -1039,17 +1039,17 @@ public final class CameraManager {
 
         private void onStatusChangedLocked(int status, String id) {
             /* Force to ignore the last mono/aux camera status update
-             * if the package name does not falls in this bucket
+             * if the package name falls in this bucket
              */
-            boolean exposeMonoCamera = false;
+            boolean exposeMonoCamera = true;
             String packageName = ActivityThread.currentOpPackageName();
-            String packageList = SystemProperties.get("camera.aux.packagelist");
+            String packageList = SystemProperties.get("camera.auxdisable.packagelist");
             if (packageList.length() > 0) {
                 TextUtils.StringSplitter splitter = new TextUtils.SimpleStringSplitter(',');
                 splitter.setString(packageList);
                 for (String str : splitter) {
                     if (packageName.equals(str)) {
-                        exposeMonoCamera = true;
+                        exposeMonoCamera = false;
                         break;
                     }
                 }


### PR DESCRIPTION
Secondary cameras work fine on our platform; there is no reason to
disable them by default. Convert the opt-in package list to be opt-out
to allow disabling packages with known incompatibilities with the dual
camera setup