### PR TITLE
PlatLogo: Show RR platlogo only when tapping on RR-OS version

### DIFF
--- a/core/java/com/android/internal/app/PlatLogoActivity.java
+++ b/core/java/com/android/internal/app/PlatLogoActivity.java
@@ -86,7 +86,9 @@ public class PlatLogoActivity extends Activity {
 
         im.setBackground(new RippleDrawable(
                 ColorStateList.valueOf(0xFFFFFFFF),
-                getDrawable(com.android.internal.R.drawable.platlogo_rr),
+                getDrawable(getIntent().getBooleanExtra("is_lineage", false)
+                        ? com.android.internal.R.drawable.platlogo_rr
+                        : com.android.internal.R.drawable.platlogo),
                 null));
 //        im.setOutlineProvider(new ViewOutlineProvider() {
 //            @Override


### PR DESCRIPTION
Let's not override default Android PlatLogo...
Just use 'is_lineage' bool for checking.
Picked from LineageOS/android_frameworks_base@2b36b6e

Change-Id: I79151cb4aff8e01a682a9c9acd0b4c9a6b12a2ce