### PR TITLE
Dialer: show headsup on incoming call even if headsup are off and tic…

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/BaseStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/BaseStatusBar.java
@@ -2919,6 +2919,22 @@ public abstract class BaseStatusBar extends SystemUI implements
         if (mNotificationData.shouldFilterOut(sbn)) {
             if (DEBUG) Log.d(TAG, "No peeking: filtered notification: " + sbn.getKey());
             return false;
+	}
+
+        final ActivityManager am = (ActivityManager)
+            mContext.getSystemService(Context.ACTIVITY_SERVICE);
+        ActivityManager.RunningTaskInfo foregroundApp = null;
+        List<ActivityManager.RunningTaskInfo> tasks = am.getRunningTasks(1);
+        if (tasks != null && !tasks.isEmpty()) {
+            foregroundApp = tasks.get(0);
+        }
+        boolean isDialerForegroundApp = foregroundApp != null &&
+                foregroundApp.baseActivity.getPackageName().toLowerCase().contains("dialer");
+        boolean isNotificationFromDialer = sbn.getPackageName().toLowerCase().contains("dialer");
+
+        boolean alwaysHeadsUpForThis = !isDialerForegroundApp && isNotificationFromDialer;
+        if ((!mUseHeadsUp && !alwaysHeadsUpForThis) || isDeviceInVrMode()) {
+            return false;
         }
 
         boolean inUse = mPowerManager.isScreenOn()


### PR DESCRIPTION
…ker on

New behaviors:
1) you are not in dialer and get a call: system shows headsup thus doesn't change
the foreground app you were on
2) you are in dialer and get a call: dialer shows incallui without headsup
3) you are in dialer and call someone: dialer shows incallui without headsup

Change-Id: I2a750d357c20c112f6d5cd8fab87784a2e53f7b9