### PR TITLE
StorageManager: fix showing external storage size as primary

### DIFF
--- a/core/java/android/os/storage/StorageManager.java
+++ b/core/java/android/os/storage/StorageManager.java
@@ -139,8 +139,8 @@ public class StorageManager {
     // try the most likely candidates - a long-term solution would be a device-specific vold
     // function that returns the calculated size.
     private static final String[] INTERNAL_STORAGE_SIZE_PATHS = {
-            "/sys/block/mmcblk0/size",
-            "/sys/block/sda/size"
+            "/sys/block/sda/size",
+            "/sys/block/mmcblk0/size"
     };
     private static final int INTERNAL_STORAGE_SECTOR_SIZE = 512;
 


### PR DESCRIPTION
in most new of devices "/sys/block/mmcblk0/size" is path of external micro sdcard size 
so when "getPrimaryStorageSize" returns first read success in "INTERNAL_STORAGE_SIZE_PATHS"
output would be size of external storage, so i just replaced "mmcblk0" to "sda" to fix it