### PR TITLE
Disable Round Icon Support

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -2838,7 +2838,7 @@
     <string name="config_carrierDemoModePackages" translatable="false"></string>
 
     <!-- Flag indicating whether round icons should be parsed from the application manifest. -->
-    <bool name="config_useRoundIcon">true</bool>
+    <bool name="config_useRoundIcon">false</bool>
 
     <!-- Flag indicating whether the assist disclosure can be disabled using
          ASSIST_DISCLOSURE_ENABLED. -->


### PR DESCRIPTION
As much as the "Round Icons" follow the Pixel Theme guidelines.. we know that not many apps have support for the Round Icons.

And we are somehow forced to bear with the inconsistency it creates in the app drawer ..

So I think it is best to use an Icon Pack for your favorite launcher (almost no one uses the default launchers anyway) such as Nova and enjoy the Round Icons for even those apps which are not using the round icons by their respective developers.. (take Facebook for ex..)