### PR TITLE
Pie: Fix FC after reboot with french language

### DIFF
--- a/packages/SystemUI/res/values-fr/rr_strings.xml
+++ b/packages/SystemUI/res/values-fr/rr_strings.xml
@@ -270,10 +270,10 @@
   <string name="no_navigation_warning_title">Toutes les méthodes de navigation sont désactivées</string>
   <string name="no_navigation_warning_text">Appuyez pour activer</string>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, jj MMMM aaaa</string>
+  <string name="pie_date_format">EEEE, dd MMMM aaaa</string>
   <string name="pie_hour_format_12">hh:mm</string>
   <string name="pie_hour_format_24">HH:mm</string>
-  <string name="pie_am_pm">un</string>
+  <string name="pie_am_pm">a</string>
   <string name="pie_state_name">Contrôles des raccourcis de l\'arc</string>
   <string name="pie_state_summary">Utiliser l\'arc en mode immersif</string>
   <string name="pie_battery_level">"BATTERIE "</string>


### PR DESCRIPTION
Enable pie, reboot the phone with automatic translation = FC
Try to fix with another language...

10-27 05:11:03.531   741   741 E AndroidRuntime: FATAL EXCEPTION: main
10-27 05:11:03.531   741   741 E AndroidRuntime: Process: com.android.systemui, PID: 741
10-27 05:11:03.531   741   741 E AndroidRuntime: java.lang.IllegalArgumentException: Illegal pattern character 'j'
10-27 05:11:03.531   741   741 E AndroidRuntime: 	at java.text.SimpleDateFormat.compile(SimpleDateFormat.java:826)
10-27 05:11:03.531   741   741 E AndroidRuntime: 	at java.text.SimpleDateFormat.initialize(SimpleDateFormat.java:640)
10-27 05:11:03.531   741   741 E AndroidRuntime: 	at java.text.SimpleDateFormat.<init>(SimpleDateFormat.java:579)
10-27 05:11:03.531   741   741 E AndroidRuntime: 	at com.android.systemui.statusbar.pie.PieMenu.getSimpleDate(PieMenu.java:1130)
10-27 05:11:03.531   741   741 E AndroidRuntime: 	at com.android.systemui.statusbar.pie.PieMenu.getDimensions(PieMenu.java:507)
10-27 05:11:03.531   741   741 E AndroidRuntime: 	at com.android.systemui.statusbar.pie.PieMenu.<init>(PieMenu.java:364)
10-27 05:11:03.531   741   741 E AndroidRuntime: 	at com.android.systemui.statusbar.pie.PieController.addPieInLocation(PieController.java:201)
10-27 05:11:03.531   741   741 E AndroidRuntime: 	at com.android.systemui.statusbar.pie.PieController.attachPie(PieController.java:168)
10-27 05:11:03.531   741   741 E AndroidRuntime: 	at com.android.systemui.statusbar.pie.PieController.resetPie(PieController.java:147)
