### PR TITLE
Fix systemUI FC when using the Language QS tile

### DIFF
--- a/packages/SystemUI/AndroidManifest.xml
+++ b/packages/SystemUI/AndroidManifest.xml
@@ -22,6 +22,7 @@
         android:sharedUserId="android.uid.systemui"
         coreApp="true">
 
+    <uses-permission android:name="android.permission.CHANGE_CONFIGURATION" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/packages/SystemUI/res/values-fr/rr_strings.xml
+++ b/packages/SystemUI/res/values-fr/rr_strings.xml
@@ -270,10 +270,10 @@
   <string name="no_navigation_warning_title">Toutes les méthodes de navigation sont désactivées</string>
   <string name="no_navigation_warning_text">Appuyez pour activer</string>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, jj MMMM aaaa</string>
+  <string name="pie_date_format">EEEE, dd MMMM aaaa</string>
   <string name="pie_hour_format_12">hh:mm</string>
   <string name="pie_hour_format_24">HH:mm</string>
-  <string name="pie_am_pm">un</string>
+  <string name="pie_am_pm">a</string>
   <string name="pie_state_name">Contrôles des raccourcis de l\'arc</string>
   <string name="pie_state_summary">Utiliser l\'arc en mode immersif</string>
   <string name="pie_battery_level">"BATTERIE "</string>


### PR DESCRIPTION
systemUI FC when using the Language QS tile. The language doesn't change (english to french).

java.lang.SecurityException: Permission Denial: updateConfiguration() from pid=7976, uid=10033 requires android.permission.CHANGE_CONFIGURATION
at android.os.Parcel.readException(Parcel.java:1684)
at android.os.Parcel.readException(Parcel.java:1637)
at android.app.ActivityManagerProxy.updatePersistentC onfiguration(ActivityManagerNative.java:6008)
at com.android.internal.app.LocalePicker.updateLocale s(LocalePicker.java:306)
at com.android.systemui.qs.tiles.LocaleTile$1.run(Loc aleTile.java:93)
at android.os.Handler.handleCallback(Handler.java:751 )
at android.os.Handler.dispatchMessage(Handler.java:95 )
at android.os.Looper.loop(Looper.java:154)
at android.os.HandlerThread.run(HandlerThread.java:61 )