### PR TITLE
base: SystemUI: Mark PIE strings as non translatable

### DIFF
--- a/packages/SystemUI/res/values-ar/rr_strings.xml
+++ b/packages/SystemUI/res/values-ar/rr_strings.xml
@@ -176,9 +176,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, dd MMMM yyyy</string>
-  <string name="pie_hour_format_12">hh:mm</string>
-  <string name="pie_hour_format_24">HH:mm</string>
   <string name="pie_state_name">تحكم Pie</string>
   <string name="pie_state_summary">استخدام عناصر تحكم Pie اثناء وضع سطح المكتب</string>
   <string name="pie_battery_level">"مستوى البطارية "</string>

--- a/packages/SystemUI/res/values-ca/rr_strings.xml
+++ b/packages/SystemUI/res/values-ca/rr_strings.xml
@@ -137,7 +137,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, dd MMMM aaaa</string>
   <string name="pie_battery_level">"NIVELL DE BATERIA "</string>
   <string name="quick_settings_pie">Pie</string>
   <string name="recents_custom_android_n">ESBORRA-HO TOT</string>

--- a/packages/SystemUI/res/values-cs/rr_strings.xml
+++ b/packages/SystemUI/res/values-cs/rr_strings.xml
@@ -176,10 +176,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, dd MMMM yyyy</string>
-  <string name="pie_hour_format_12">hh:mm</string>
-  <string name="pie_hour_format_24">HH: mm</string>
-  <string name="pie_am_pm">a</string>
   <string name="pie_state_name">Pie ovládání</string>
   <string name="pie_state_summary">Použít prvky Pie v pohlcujícím režimu</string>
   <string name="pie_battery_level">"ÚROVEŇ NABITÍ BATERIE "</string>

--- a/packages/SystemUI/res/values-de/rr_strings.xml
+++ b/packages/SystemUI/res/values-de/rr_strings.xml
@@ -176,10 +176,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, dd MMMM yyyy</string>
-  <string name="pie_hour_format_12">hh:mm</string>
-  <string name="pie_hour_format_24">HH:mm</string>
-  <string name="pie_am_pm">AM/PM</string>
   <string name="pie_state_name">Pie-Steuerung</string>
   <string name="pie_state_summary">Pie-Steuerungen während des Immersive-Modus verwenden</string>
   <string name="pie_battery_level">"AKKUSTAND "</string>

--- a/packages/SystemUI/res/values-el/rr_strings.xml
+++ b/packages/SystemUI/res/values-el/rr_strings.xml
@@ -176,10 +176,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, dd MMMM yyyy</string>
-  <string name="pie_hour_format_12">ωω:λλ</string>
-  <string name="pie_hour_format_24">ΩΩ:λλ</string>
-  <string name="pie_am_pm">π</string>
   <string name="pie_state_name">Χειρισμοί Pie</string>
   <string name="pie_state_summary">Χρησιμοποιήστε χειρισμό pie ενώ ειναι στη λειτουργία πλήρους οθόνης</string>
   <string name="pie_battery_level">"ΕΠΙΠΕΔΟ ΜΠΑΤΑΡΙΑΣ "</string>

--- a/packages/SystemUI/res/values-es/rr_strings.xml
+++ b/packages/SystemUI/res/values-es/rr_strings.xml
@@ -176,10 +176,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, dd MMMM aaaa</string>
-  <string name="pie_hour_format_12">hh:mm</string>
-  <string name="pie_hour_format_24">HH:mm</string>
-  <string name="pie_am_pm">a</string>
   <string name="pie_state_name">Controles Pie</string>
   <string name="pie_state_summary">Usar controles Pie en modo inmersivo</string>
   <string name="pie_battery_level">"NIVEL DE BATERÍA "</string>

--- a/packages/SystemUI/res/values-fi/rr_strings.xml
+++ b/packages/SystemUI/res/values-fi/rr_strings.xml
@@ -176,7 +176,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, dd MMMM yyyy</string>
   <string name="pie_state_name">Pie-ohjaus</string>
   <string name="recents_custom_android_n">TYHJENNÄ KAIKKI</string>
 </resources>

--- a/packages/SystemUI/res/values-fr/rr_strings.xml
+++ b/packages/SystemUI/res/values-fr/rr_strings.xml
@@ -176,10 +176,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, jj MMMM aaaa</string>
-  <string name="pie_hour_format_12">hh:mm</string>
-  <string name="pie_hour_format_24">HH:mm</string>
-  <string name="pie_am_pm">un</string>
   <string name="pie_state_name">Contrôles des raccourcis de l\'arc</string>
   <string name="pie_state_summary">Utiliser l\'arc en mode immersif</string>
   <string name="pie_battery_level">"BATTERIE "</string>

--- a/packages/SystemUI/res/values-hi/rr_strings.xml
+++ b/packages/SystemUI/res/values-hi/rr_strings.xml
@@ -176,10 +176,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, dd MMMM yyyy</string>
-  <string name="pie_hour_format_12">घंटे:मिनट</string>
-  <string name="pie_hour_format_24">HH:mm</string>
-  <string name="pie_am_pm">a</string>
   <string name="pie_state_name">पाइ नियंत्रण</string>
   <string name="pie_state_summary">इमर्सिव मोड मे होने पर पाई कंट्रोल्स का उपयोग करें</string>
   <string name="pie_battery_level">"बैटरी स्तर "</string>

--- a/packages/SystemUI/res/values-hr/rr_strings.xml
+++ b/packages/SystemUI/res/values-hr/rr_strings.xml
@@ -176,7 +176,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, dd MMMM yyyy</string>
   <string name="pie_state_name">Kontrola pitom</string>
   <string name="pie_state_summary">Upotreba kontrola pitom u cjelozaslonskom načinu</string>
   <string name="pie_battery_level">"RAZINA BATERIJE "</string>

--- a/packages/SystemUI/res/values-hu/rr_strings.xml
+++ b/packages/SystemUI/res/values-hu/rr_strings.xml
@@ -176,7 +176,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, yyyy MMMM dd</string>
   <string name="pie_state_name">Pie vezérlő</string>
   <string name="pie_state_summary">Pie vezérlő használata teljes képernyős üzemmódban</string>
   <string name="pie_battery_level">"AKKUMULÁTOR SZINTJE "</string>

--- a/packages/SystemUI/res/values-in/rr_strings.xml
+++ b/packages/SystemUI/res/values-in/rr_strings.xml
@@ -176,10 +176,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, dd MMMM yyyy</string>
-  <string name="pie_hour_format_12">hh:mm</string>
-  <string name="pie_hour_format_24">HH:mm</string>
-  <string name="pie_am_pm">a</string>
   <string name="pie_state_name">Kontrol navigasi PIE</string>
   <string name="pie_state_summary">Gunakan kontrol pie ketika dalam mode layar penuh</string>
   <string name="pie_battery_level">"TINGKAT BATERAI "</string>

--- a/packages/SystemUI/res/values-it/rr_strings.xml
+++ b/packages/SystemUI/res/values-it/rr_strings.xml
@@ -176,11 +176,7 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s </xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, gg MMMM aaaa</string>
-  <string name="pie_hour_format_12">oo:mm</string>
-  <string name="pie_hour_format_24">OO:mm</string>
-  <string name="pie_am_pm">un</string>
-  <string name="pie_state_name">Linguetta di controllo</string>
+  <string name="pie_state_name">Controlli Pie</string>
   <string name="pie_state_summary">In modalità immersiva, usa controlli a scomparsa</string>
   <string name="pie_battery_level">"LIVELLO BATTERIA "</string>
   <string name="quick_settings_pie">Pie</string>

--- a/packages/SystemUI/res/values-ja/rr_strings.xml
+++ b/packages/SystemUI/res/values-ja/rr_strings.xml
@@ -137,7 +137,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, dd MMMM yyyy</string>
   <string name="pie_state_name">Pie コントロール</string>
   <string name="pie_state_summary">没入型モードでPieコントロールを使用する</string>
   <string name="pie_battery_level">"バッテリーレベル "</string>

--- a/packages/SystemUI/res/values-ko/rr_strings.xml
+++ b/packages/SystemUI/res/values-ko/rr_strings.xml
@@ -147,7 +147,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">yyyy MMMM dd, EEEE</string>
   <string name="pie_state_name">파이 컨트롤</string>
   <string name="pie_state_summary">전체 화면 모드에서 파이 컨트롤 사용</string>
   <string name="pie_battery_level">"배터리 잔량 "</string>

--- a/packages/SystemUI/res/values-nl/rr_strings.xml
+++ b/packages/SystemUI/res/values-nl/rr_strings.xml
@@ -176,10 +176,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, dd MMMM yyyy</string>
-  <string name="pie_hour_format_12">hh:mm</string>
-  <string name="pie_hour_format_24">HH:mm</string>
-  <string name="pie_am_pm">a</string>
   <string name="pie_state_name">Pie besturing</string>
   <string name="pie_state_summary">Gebruik pie besturing in immersieve modus</string>
   <string name="pie_battery_level">"BATTERIJNIVEAU "</string>

--- a/packages/SystemUI/res/values-pl/rr_strings.xml
+++ b/packages/SystemUI/res/values-pl/rr_strings.xml
@@ -176,10 +176,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, dd MMMM yyyy</string>
-  <string name="pie_hour_format_12">gg:mm</string>
-  <string name="pie_hour_format_24">GG:mm</string>
-  <string name="pie_am_pm">a</string>
   <string name="pie_state_name">Kontrola PIE</string>
   <string name="pie_state_summary">Używaj kontroli PIE w trybie pełnoekranowym</string>
   <string name="pie_battery_level">"POZIOM NAŁADOWANIA BATERII "</string>

--- a/packages/SystemUI/res/values-pt-rBR/rr_strings.xml
+++ b/packages/SystemUI/res/values-pt-rBR/rr_strings.xml
@@ -176,10 +176,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, dd MMMM yyyy</string>
-  <string name="pie_hour_format_12">hh:mm</string>
-  <string name="pie_hour_format_24">HH:mm</string>
-  <string name="pie_am_pm">a</string>
   <string name="pie_state_name">Controles Pie</string>
   <string name="pie_state_summary">Usar o controle pie durante o modo imersivo</string>
   <string name="pie_battery_level">"NÍVEL DE BATERIA "</string>

--- a/packages/SystemUI/res/values-pt-rPT/rr_strings.xml
+++ b/packages/SystemUI/res/values-pt-rPT/rr_strings.xml
@@ -176,10 +176,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, dd MMMM yyyy</string>
-  <string name="pie_hour_format_12">hh:mm</string>
-  <string name="pie_hour_format_24">HH:mm</string>
-  <string name="pie_am_pm">a</string>
   <string name="pie_state_name">Controlos Pie</string>
   <string name="pie_state_summary">Use os controlos Pie durante o modo imersivo</string>
   <string name="pie_battery_level">"Nível de bateria "</string>

--- a/packages/SystemUI/res/values-ro/rr_strings.xml
+++ b/packages/SystemUI/res/values-ro/rr_strings.xml
@@ -176,7 +176,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s </xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, dd MMMM yyyy</string>
   <string name="pie_state_name">Control Evantai</string>
   <string name="pie_state_summary">Utilizaţi controale evantai în modul imersiv</string>
   <string name="pie_battery_level">"NIVELUL BATERIEI "</string>

--- a/packages/SystemUI/res/values-ru/rr_strings.xml
+++ b/packages/SystemUI/res/values-ru/rr_strings.xml
@@ -176,9 +176,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, дд ММММ гггг</string>
-  <string name="pie_hour_format_12">чч:мм</string>
-  <string name="pie_hour_format_24">ЧЧ:мм</string>
   <string name="pie_state_name">PIE-управление</string>
   <string name="pie_state_summary">Использовать PIE-управление в полноэкранном режиме</string>
   <string name="pie_battery_level">"Заряд батареи"</string>

--- a/packages/SystemUI/res/values-sk/rr_strings.xml
+++ b/packages/SystemUI/res/values-sk/rr_strings.xml
@@ -176,10 +176,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, dd MMMM yyyy</string>
-  <string name="pie_hour_format_12">hh:mm</string>
-  <string name="pie_hour_format_24">HH:MM</string>
-  <string name="pie_am_pm">AM/PM</string>
   <string name="pie_state_name">Kruhové ovládanie</string>
   <string name="pie_state_summary">Použiť kruhové ovládacie prvky v pohlcujúcom režime</string>
   <string name="pie_battery_level">"ÚROVEŇ NABITIA BATÉRIE "</string>

--- a/packages/SystemUI/res/values-sr/rr_strings.xml
+++ b/packages/SystemUI/res/values-sr/rr_strings.xml
@@ -137,10 +137,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, dd MMMM yyyy</string>
-  <string name="pie_hour_format_12">hh:mm</string>
-  <string name="pie_hour_format_24">HH:mm</string>
-  <string name="pie_am_pm">а</string>
   <string name="pie_state_name">\"Пита\" контроле</string>
   <string name="pie_state_summary">Употреба конторла пите у раду преко целог екрана</string>
   <string name="pie_battery_level">"НИВО БАТЕРИЈЕ "</string>

--- a/packages/SystemUI/res/values-sv/rr_strings.xml
+++ b/packages/SystemUI/res/values-sv/rr_strings.xml
@@ -173,9 +173,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, dd MMMM yyyy</string>
-  <string name="pie_hour_format_12">hh:mm</string>
-  <string name="pie_hour_format_24">HH:mm</string>
   <string name="pie_state_name">Pie-kontroller</string>
   <string name="pie_state_summary">Använd pie-kontroller i integrerat läge</string>
   <string name="pie_battery_level">"BATTERINIVÅ "</string>

--- a/packages/SystemUI/res/values-th/rr_strings.xml
+++ b/packages/SystemUI/res/values-th/rr_strings.xml
@@ -155,7 +155,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, dd MMMM yyyy</string>
   <string name="pie_state_name">ควบคุมแบบวงกลม</string>
   <string name="pie_state_summary">ใช้พายควบคุมขณะอยู่ในโหมดใหญ่พิเศษ</string>
   <string name="pie_battery_level">"ระดับแบตเตอรี่ "</string>

--- a/packages/SystemUI/res/values-tr/rr_strings.xml
+++ b/packages/SystemUI/res/values-tr/rr_strings.xml
@@ -176,10 +176,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, dd MMMM yyyy</string>
-  <string name="pie_hour_format_12">ss:dd</string>
-  <string name="pie_hour_format_24">HH:mm</string>
-  <string name="pie_am_pm">a</string>
   <string name="pie_state_name">Pie kontrolleri</string>
   <string name="pie_state_summary">Tam ekran modundayken pie kontrollerini kullanın</string>
   <string name="pie_battery_level">"PİL SEVİYESİ "</string>

--- a/packages/SystemUI/res/values-uk/rr_strings.xml
+++ b/packages/SystemUI/res/values-uk/rr_strings.xml
@@ -176,10 +176,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, dd MMMM yyyy</string>
-  <string name="pie_hour_format_12">hh:mm</string>
-  <string name="pie_hour_format_24">HH:mm</string>
-  <string name="pie_am_pm">a</string>
   <string name="pie_state_name">Управління PIE</string>
   <string name="pie_state_summary">Використовувати керування PIE в повноекранному режимі</string>
   <string name="pie_battery_level">"Заряд батареї"</string>

--- a/packages/SystemUI/res/values-vi/rr_strings.xml
+++ b/packages/SystemUI/res/values-vi/rr_strings.xml
@@ -176,10 +176,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEEE, dd MMMM yyyy</string>
-  <string name="pie_hour_format_12">giờ:phút</string>
-  <string name="pie_hour_format_24">Giờ:phút</string>
-  <string name="pie_am_pm">am</string>
   <string name="pie_state_name">Điều hướng Pie</string>
   <string name="pie_state_summary">Sử dụng điều khiển pie khi ở chế độ nhập vai</string>
   <string name="pie_battery_level">"MỨC PIN "</string>

--- a/packages/SystemUI/res/values-zh-rCN/rr_strings.xml
+++ b/packages/SystemUI/res/values-zh-rCN/rr_strings.xml
@@ -176,10 +176,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">星期，日月年</string>
-  <string name="pie_hour_format_12">hh:mm</string>
-  <string name="pie_hour_format_24">HH:mm</string>
-  <string name="pie_am_pm">a</string>
   <string name="pie_state_name">Pie 控制</string>
   <string name="pie_state_summary">在沉浸模式下启用 Pie 控制</string>
   <string name="pie_battery_level">"电池电量 "</string>

--- a/packages/SystemUI/res/values-zh-rHK/rr_strings.xml
+++ b/packages/SystemUI/res/values-zh-rHK/rr_strings.xml
@@ -176,10 +176,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">EEE, dd MMMM yyyy</string>
-  <string name="pie_hour_format_12">hh:mm</string>
-  <string name="pie_hour_format_24">HH:mm</string>
-  <string name="pie_am_pm">a</string>
   <string name="pie_state_name">Pie 按鈕</string>
   <string name="pie_state_summary">在全螢幕模式中使用扇形控制</string>
   <string name="pie_battery_level">"電池計量水準 "</string>

--- a/packages/SystemUI/res/values-zh-rTW/rr_strings.xml
+++ b/packages/SystemUI/res/values-zh-rTW/rr_strings.xml
@@ -176,8 +176,6 @@
   <string name="status_bar_weather_format"><xliff:g id="temp">%1$s</xliff:g></string>
   <dimen name="screenrecord_hint_size">48dp</dimen>
   <!-- Pie controls -->
-  <string name="pie_date_format">yyyy MMMM dd, EEEE</string>
-  <string name="pie_hour_format_12">小時:分鐘</string>
   <string name="pie_state_name">扇形控制項</string>
   <string name="pie_state_summary">在全螢幕模式中使用扇形控制項</string>
   <string name="pie_battery_level">"電池電量 "</string>

--- a/packages/SystemUI/res/values/rr_strings.xml
+++ b/packages/SystemUI/res/values/rr_strings.xml
@@ -215,10 +215,10 @@
   <dimen name="screenrecord_hint_size">48dp</dimen>
 
     <!-- Pie controls -->
-    <string name="pie_date_format">EEEE, dd MMMM yyyy</string>
-    <string name="pie_hour_format_12">hh:mm</string>
-    <string name="pie_hour_format_24">HH:mm</string>
-    <string name="pie_am_pm">a</string>
+    <string name="pie_date_format" translatable="false">EEEE, dd MMMM yyyy</string>
+    <string name="pie_hour_format_12" translatable="false">hh:mm</string>
+    <string name="pie_hour_format_24" translatable="false">HH:mm</string>
+    <string name="pie_am_pm" translatable="false">a</string>
     <string name="pie_state_name">Pie controls</string>
     <string name="pie_state_summary">Use pie controls while in immersive mode</string>
     <string name="pie_battery_level">"BATTERY LEVEL "</string>


### PR DESCRIPTION
This is actually needed so Crowdin does not allow users to translate them
and since they need to be exactly like this there is no reason on translating.

Also this fixes issues for the 8.1.0 release

Adapted for Resurrection Remix based on AOSPA Source.

Thanks to @Herna1994 