### PR TITLE
base: Expand header image size

### DIFF
--- a/packages/SystemUI/res/layout/quick_status_bar_expanded_header.xml
+++ b/packages/SystemUI/res/layout/quick_status_bar_expanded_header.xml
@@ -37,8 +37,7 @@
         android:layout_height="match_parent"
         android:clipChildren="true"
         android:clipToPadding="true"
-        android:layout_gravity="center"
-        android:paddingBottom="@dimen/qs_panel_footer_height" >
+        android:layout_gravity="center" >
 
         <ImageView android:id="@+id/qs_header_image"
             android:layout_width="match_parent"

--- a/packages/SystemUI/res/values/rr_dimens.xml
+++ b/packages/SystemUI/res/values/rr_dimens.xml
@@ -40,7 +40,7 @@
     <dimen name="qs_tile_height_wo_label">48dp</dimen>
 
     <dimen name="qs_panel_margin_top">25dp</dimen>
-    <dimen name="qs_panel_margin_top_header">85dp</dimen>
+    <dimen name="qs_panel_margin_top_header">120dp</dimen>
     <dimen name="qs_scroller_top_margin">40dp</dimen>
     <dimen name="qs_panel_footer_height">40dp</dimen>
 


### PR DESCRIPTION
This shows the omnistyle header on a bigger size, taking all the statusbar instead of leaving the QS Footer clean.
Made it like old nougat times

Also, taken the way that omni made the padding between the qs header and the icon when this is enabled and recreate it just for this.