### PR TITLE
SystemUI: fix of random falls when changing theme

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/stack/NotificationStackScrollLayout.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/stack/NotificationStackScrollLayout.java
@@ -3078,7 +3078,8 @@ public class NotificationStackScrollLayout extends ViewGroup
             }
             if (!childWasSwipedOut) {
                 Rect clipBounds = child.getClipBounds();
-                childWasSwipedOut = clipBounds.height() == 0;
+                if (clipBounds != null)
+                    childWasSwipedOut = clipBounds.height() == 0;
             }
             int animationType = childWasSwipedOut
                     ? AnimationEvent.ANIMATION_TYPE_REMOVE_SWIPED_OUT


### PR DESCRIPTION
--------- beginning of crash
06-16 07:58:38.775  4113  4113 E AndroidRuntime: FATAL EXCEPTION: main
06-16 07:58:38.775  4113  4113 E AndroidRuntime: Process: com.android.systemui, PID: 4113
06-16 07:58:38.775  4113  4113 E AndroidRuntime: java.lang.NullPointerException: Attempt to invoke virtual method 'int android.graphics.Rect.height()'  on a null object reference
06-16 07:58:38.775  4113  4113 E AndroidRuntime:        at com.android.systemui.statusbar.stack.NotificationStackScrollLayout.generateChildRemovalEvents(NotificationStackScrollLayout.java:3081)
06-16 07:58:38.775  4113  4113 E AndroidRuntime:        at com.android.systemui.statusbar.stack.NotificationStackScrollLayout.generateChildHierarchyEvents(NotificationStackScrollLayout.java:2966)
06-16 07:58:38.775  4113  4113 E AndroidRuntime:        at com.android.systemui.statusbar.stack.NotificationStackScrollLayout.startAnimationToState(NotificationStackScrollLayout.java:2948)
06-16 07:58:38.775  4113  4113 E AndroidRuntime:        at com.android.systemui.statusbar.stack.NotificationStackScrollLayout.updateChildren(NotificationStackScrollLayout.java:644)
06-16 07:58:38.775  4113  4113 E AndroidRuntime:        at com.android.systemui.statusbar.stack.NotificationStackScrollLayout.-wrap8(Unknown Source:0)
06-16 07:58:38.775  4113  4113 E AndroidRuntime:        at com.android.systemui.statusbar.stack.NotificationStackScrollLayout$1.onPreDraw(NotificationStackScrollLayout.java:265)
06-16 07:58:38.775  4113  4113 E AndroidRuntime:        at android.view.ViewTreeObserver.dispatchOnPreDraw(ViewTreeObserver.java:977)
06-16 07:58:38.775  4113  4113 E AndroidRuntime:        at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:2364)
06-16 07:58:38.775  4113  4113 E AndroidRuntime:        at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1407)
06-16 07:58:38.775  4113  4113 E AndroidRuntime:        at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:6783)
06-16 07:58:38.775  4113  4113 E AndroidRuntime:        at android.view.Choreographer$CallbackRecord.run(Choreographer.java:911)
06-16 07:58:38.775  4113  4113 E AndroidRuntime:        at android.view.Choreographer.doCallbacks(Choreographer.java:723)
06-16 07:58:38.775  4113  4113 E AndroidRuntime:        at android.view.Choreographer.doFrame(Choreographer.java:658)
06-16 07:58:38.775  4113  4113 E AndroidRuntime:        at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:897)
06-16 07:58:38.775  4113  4113 E AndroidRuntime:        at android.os.Handler.handleCallback(Handler.java:790)
06-16 07:58:38.775  4113  4113 E AndroidRuntime:        at android.os.Handler.dispatchMessage(Handler.java:99)
06-16 07:58:38.775  4113  4113 E AndroidRuntime:        at android.os.Looper.loop(Looper.java:164)
06-16 07:58:38.775  4113  4113 E AndroidRuntime:        at android.app.ActivityThread.main(ActivityThread.java:6499)
06-16 07:58:38.775  4113  4113 E AndroidRuntime:        at java.lang.reflect.Method.invoke(Native Method)
06-16 07:58:38.775  4113  4113 E AndroidRuntime:        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:440)
06-16 07:58:38.775  4113  4113 E AndroidRuntime:        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)
06-16 07:58:38.780   472 11292 W ActivityManager:   Force finishing activity com.android.systemui/.recents.RecentsActivity