### PR TITLE
start ScreenStateService after reboot

### DIFF
--- a/core/java/com/android/server/BootReceiver.java
+++ b/core/java/com/android/server/BootReceiver.java
@@ -31,6 +31,7 @@ import android.os.ServiceManager;
 import android.os.SystemProperties;
 import android.os.storage.StorageManager;
 import android.provider.Downloads;
+import android.provider.Settings;
 import android.text.TextUtils;
 import android.util.AtomicFile;
 import android.util.Slog;
@@ -135,7 +136,16 @@ public class BootReceiver extends BroadcastReceiver {
                 } catch (Exception e) {
                     Slog.e(TAG, "Can't remove old update packages", e);
                 }
-
+                try {
+                    if (Settings.System.getInt(context.getContentResolver(),
+                                    Settings.System.START_SCREEN_STATE_SERVICE, 0) != 0) {
+                        Intent screenstate = (new Intent()).setClassName("com.android.systemui",
+                                "com.android.systemui.screenstate.ScreenStateService");
+                        context.startService(screenstate);
+                    }
+                } catch (Exception e) {
+                    Slog.e(TAG, "Can't start the screen state service", e);
+                }
             }
         }.start();
     }


### PR DESCRIPTION
It is necessary for the Suspend Actions from Miscellaneous settings.