### PR TITLE
Base: fix miss merge

### DIFF
--- a/services/core/java/com/android/server/am/ActivityManagerService.java
+++ b/services/core/java/com/android/server/am/ActivityManagerService.java
@@ -582,8 +582,6 @@ public class ActivityManagerService extends IActivityManager.Stub
     // How long we wait for an attached process to publish its content providers
     // before we decide it must be hung.
     static final int CONTENT_PROVIDER_PUBLISH_TIMEOUT = 10*1000;
-    // How long we wait for provider to be notify before we decide it may be hang.
-    static final int CONTENT_PROVIDER_WAIT_TIMEOUT = 20*1000;
 
     /**
      * How long we wait for an provider to be published. Should be longer than
@@ -5993,7 +5991,6 @@ public class ActivityManagerService extends IActivityManager.Stub
     private final void handleAppDiedLocked(ProcessRecord app,
             boolean restarting, boolean allowRestart) {
         int pid = app.pid;
-        final boolean clearLaunchStartTime = !restarting && app.removed && app.foregroundActivities;
         boolean kept = cleanUpApplicationRecordLocked(app, restarting, allowRestart, -1,
                 false /*replacingPid*/);
         if (!kept && !restarting) {
@@ -6035,18 +6032,6 @@ public class ActivityManagerService extends IActivityManager.Stub
             mWindowManager.continueSurfaceLayout();
         }
 
-        // Hack for pi
-        // When an app process is removed, activities from the process may be relaunched. In the
-        // case of forceStopPackageLocked the activities are finished before any window is drawn,
-        // and the launch time is not cleared. This will be incorrectly used to calculate launch
-        // time for the next launched activity launched in the same windowing mode.
-        if (clearLaunchStartTime) {
-            final LaunchTimeTracker.Entry entry = mStackSupervisor
-                    .getLaunchTimeTracker().getEntry(mStackSupervisor.getWindowingMode());
-            if (entry != null) {
-                entry.mLaunchStartTime = 0;
-            }
-        }
     }
 
     private final int getLRURecordIndexForAppLocked(IApplicationThread thread) {


### PR DESCRIPTION
CONTENT_PROVIDER_WAIT_TIMEOUT is duplicated

clearLaunchStartTime was removed in
https://github.com/fgl27/android_frameworks_base/commit/cf23504955906fc1d859187ac4ba999c53d31f63#diff-2d1a69d874ae839ad68ec2838d40f678

Signed-off-by: Felipe Leon <fglfgl27@gmail.com>