### PR TITLE
Add Sound tile to Quick Settings

### DIFF
--- a/packages/SystemUI/res/values/config.xml
+++ b/packages/SystemUI/res/values/config.xml
@@ -122,7 +122,7 @@
     </string>
 
     <!-- Tiles native to System UI. Order should match "quick_settings_tiles_default" -->
-    <string name="quick_settings_tiles_stock" translatable="false"> wifi,cell,battery,dnd,flashlight,rotation,bt,airplane,nfc,location,hotspot,inversion,saver,work,cast,night,adb_network,ambient_display,caffeine,heads_up,livedisplay,reading_mode,sync,usb_tether,volume_panel,lte,screenshot,screenrecord,reboot,pie,smartpixels,weather,gaming,aod,onehand
+    <string name="quick_settings_tiles_stock" translatable="false"> wifi,cell,battery,dnd,flashlight,rotation,bt,airplane,nfc,location,hotspot,inversion,saver,work,cast,night,adb_network,ambient_display,caffeine,heads_up,livedisplay,reading_mode,sync,usb_tether,volume_panel,lte,screenshot,screenrecord,reboot,pie,smartpixels,weather,gaming,aod,onehand,sound
     </string>
 
     <!-- The tiles to display in QuickSettings -->

--- a/packages/SystemUI/res/values/rr_strings.xml
+++ b/packages/SystemUI/res/values/rr_strings.xml
@@ -54,6 +54,12 @@
     <string name="quick_settings_screenrecord_mq_label">Screenrecord 720p</string>
     <string name="quick_settings_screenrecord_hq_label">Screenrecord 720p+</string>
 
+    <!-- Sound QS Tile -->
+    <string name="quick_settings_sound_label">Sound</string>
+    <string name="quick_settings_sound_ring">Ring</string>
+    <string name="quick_settings_sound_vibrate">Vibrate</string>
+    <string name="quick_settings_sound_dnd">Do not disturb</string>
+
     <!-- Screenshot Delete Toast -->
     <string name="delete_screenshot_toast">Screenshot deleted</string>
 

--- a/packages/SystemUI/src/com/android/systemui/qs/tileimpl/QSFactoryImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tileimpl/QSFactoryImpl.java
@@ -53,6 +53,7 @@ import com.android.systemui.qs.tiles.RotationLockTile;
 import com.android.systemui.qs.tiles.SmartPixelsTile;
 import com.android.systemui.qs.tiles.SyncTile;
 import com.android.systemui.qs.tiles.UsbTetherTile;
+import com.android.systemui.qs.tiles.SoundTile;
 import com.android.systemui.qs.tiles.UserTile;
 import com.android.systemui.qs.tiles.VolumeTile;
 import com.android.systemui.qs.tiles.WifiTile;
@@ -157,6 +158,8 @@ public class QSFactoryImpl implements QSFactory {
                 return new AODTile(mHost);
             case "onehand":
                 return new OneHandTile(mHost);
+            case "sound":
+                return new SoundTile(mHost);
         }
 
         // Intent tiles.

--- a/packages/SystemUI/src/com/android/systemui/qs/tiles/SoundTile.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/tiles/SoundTile.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.systemui.qs.tiles;
+
+import android.content.BroadcastReceiver;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.media.AudioManager;
+import android.provider.Settings.Global;
+import android.service.quicksettings.Tile;
+
+import com.android.internal.logging.nano.MetricsProto.MetricsEvent;
+import com.android.systemui.Dependency;
+import com.android.systemui.qs.QSHost;
+import com.android.systemui.plugins.qs.QSTile.BooleanState;
+import com.android.systemui.qs.tileimpl.QSTileImpl;
+import com.android.systemui.R;
+import com.android.systemui.statusbar.policy.ZenModeController;
+
+public class SoundTile extends QSTileImpl<BooleanState> {
+
+    private final ZenModeController mZenController;
+    private final AudioManager mAudioManager;
+
+    private boolean mListening = false;
+
+    private BroadcastReceiver mReceiver;
+    private IntentFilter mFilter;
+
+    public SoundTile(QSHost host) {
+        super(host);
+        mZenController = Dependency.get(ZenModeController.class);
+        mAudioManager = (AudioManager) mContext.getSystemService(Context.AUDIO_SERVICE);
+        mReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                refreshState();
+            }
+        };
+    }
+
+    @Override
+    public BooleanState newTileState() {
+        return new BooleanState();
+    }
+
+    @Override
+    public void handleSetListening(boolean listening) {
+        if (mListening == listening) return;
+        mListening = listening;
+        if (listening) {
+            final IntentFilter filter = new IntentFilter();
+            filter.addAction(AudioManager.INTERNAL_RINGER_MODE_CHANGED_ACTION);
+            mContext.registerReceiver(mReceiver, filter);
+        } else {
+            mContext.unregisterReceiver(mReceiver);
+        }
+    }
+
+    @Override
+    public void handleClick() {
+        updateState();
+    }
+
+    @Override
+    public void handleLongClick() {
+        mAudioManager.adjustVolume(AudioManager.ADJUST_SAME, AudioManager.FLAG_SHOW_UI);
+    }
+
+    @Override
+    public Intent getLongClickIntent() {
+        return null;
+    }
+
+    private void updateState() {
+        int oldState = mAudioManager.getRingerModeInternal();
+        int newState = oldState;
+        switch (oldState) {
+            case AudioManager.RINGER_MODE_NORMAL:
+                newState = AudioManager.RINGER_MODE_VIBRATE;
+                mAudioManager.setRingerModeInternal(newState);
+                break;
+            case AudioManager.RINGER_MODE_VIBRATE:
+                newState = AudioManager.RINGER_MODE_SILENT;
+                mZenController.setZen(Global.ZEN_MODE_NO_INTERRUPTIONS, null, TAG);
+                break;
+            case AudioManager.RINGER_MODE_SILENT:
+                newState = AudioManager.RINGER_MODE_NORMAL;
+                mZenController.setZen(Global.ZEN_MODE_OFF, null, TAG);
+                mAudioManager.setRingerModeInternal(newState);
+                break;
+            default:
+                break;
+        }
+    }
+
+    @Override
+    public CharSequence getTileLabel() {
+        return mContext.getString(R.string.quick_settings_sound_label);
+    }
+
+    @Override
+    protected void handleUpdateState(BooleanState state, Object arg) {
+        switch (mAudioManager.getRingerModeInternal()) {
+            case AudioManager.RINGER_MODE_NORMAL:
+                state.icon = ResourceIcon.get(R.drawable.ic_qs_ringer_audible);
+                state.label = mContext.getString(R.string.quick_settings_sound_ring);
+                state.contentDescription =  mContext.getString(
+                        R.string.quick_settings_sound_ring);
+                break;
+            case AudioManager.RINGER_MODE_VIBRATE:
+                state.icon = ResourceIcon.get(R.drawable.ic_qs_ringer_vibrate);
+                state.label = mContext.getString(R.string.quick_settings_sound_vibrate);
+                state.contentDescription =  mContext.getString(
+                        R.string.quick_settings_sound_vibrate);
+                break;
+            case AudioManager.RINGER_MODE_SILENT:
+                state.icon = ResourceIcon.get(R.drawable.ic_qs_ringer_silent);
+                state.label = mContext.getString(R.string.quick_settings_sound_dnd);
+                state.contentDescription =  mContext.getString(
+                        R.string.quick_settings_sound_dnd);
+                break;
+            default:
+                break;
+        }
+    }
+
+    @Override
+    public int getMetricsCategory() {
+return MetricsEvent.RESURRECTED;
+    }
+}


### PR DESCRIPTION
abc ezio84: adapt to O, show volume panel with long press,
use full dnd (no interruptions) as silent mode

@beanstown106: Sound Tile improvements
*added longpress action
*added more descriptive labels for each state instead of always saying sound
ezio84: Adapt for N

Change-Id: I2f5d69bf04148cb0a7fae9fd72741c134f18a1a8
Signed-off-by: Josh Fox(XlxFoXxlX) <joshfox87@gmail.com>