### PR TITLE
Incall vibration options [1/3]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -5417,6 +5417,24 @@ public final class Settings {
         public static final String QS_TILE_STYLE = "qs_tile_style";
 
         /**
+         * Whether the phone vibrates on call connect
+         * @hide
+         */
+        public static final String VIBRATE_ON_CONNECT = "vibrate_on_connect";
+
+         /**
+         * Whether the phone vibrates on call waiting
+         * @hide
+         */
+        public static final String VIBRATE_ON_CALLWAITING = "vibrate_on_callwaiting";
+
+         /**
+         * Whether the phone vibrates on disconnect
+         * @hide
+         */
+        public static final String VIBRATE_ON_DISCONNECT = "vibrate_on_disconnect";
+
+        /**
          * Settings to backup. This is here so that it's in the same place as the settings
          * keys and easy to update.
          *


### PR DESCRIPTION
allow setting vibration when call is connected
allow setting vibration when call is disconnected allow setting vibration for call waiting

this works with google and aosp dialer :)

Signed-off-by: Pranav Vashi <neobuddy89@gmail.com>

 Conflicts:
	core/java/android/provider/Settings.java

Change-Id: I95274e05c6a6f36aea691bc6bd6f7fbab8dc28cc