### PR TITLE
SystemUI: Handle orientation and screenSize changes for TunerActivity

### DIFF
--- a/packages/SystemUI/AndroidManifest.xml
+++ b/packages/SystemUI/AndroidManifest.xml
@@ -325,6 +325,7 @@
                   android:theme="@style/TunerSettings"
                   android:label="@string/system_ui_tuner"
                   android:process=":tuner"
+		  android:configChanges="orientation|screenSize"
                   android:parentActivityName="com.android.settings.rr.MainSettingsLayout"
                   android:exported="true">
         </activity>


### PR DESCRIPTION
* Fixes NPE on calling Dependency.get() after
  rotating the device while showing navigation
  bar tuner fragment.

Change-Id: I4e65c46d42e6691a67aefa5d065e7cab57464fc2