### PR TITLE
SystemUI: Protect against terrible music players

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/notification/NotificationMediaTemplateViewWrapper.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/notification/NotificationMediaTemplateViewWrapper.java
@@ -109,7 +109,7 @@ public class NotificationMediaTemplateViewWrapper extends NotificationTemplateVi
                 mSeekBar.setMax((int) mDuration);
                 mSeekBarTotalTime.setText(millisecondsToTimeString(duration));
             }
-            if (!mTrackingTouch) {
+            if (!mTrackingTouch && mMediaController.getPlaybackState() != null) {
                 long position = mMediaController.getPlaybackState().getPosition();
                 mSeekBar.setProgress((int) position);
             }


### PR DESCRIPTION
For reasons unknown Gaana sets a null playback state in some cases
causing seekbar update runnable to throw exceptions and shut everything
down. Quickfix this nonsense while we wait 3 years for the app to
get its shit together.

Change-Id: I284d3018748ad967c5f5cbffa32caf016ec69eba
Signed-off-by: Harsh Shandilya <harsh@prjkt.io>