### PR TITLE
Add support for faked GmsCore microG location provider 

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -1718,7 +1718,7 @@
         <item>com.android.location.fused</item>
         <!-- microG unifiednlp location provider (standalone) -->
         <item>org.microg.nlp</item>
-	<!-- The (faked) microg fused location provider (a free reimplementation) -->
+        <!-- The (faked) microg fused location provider (a free reimplementation) -->
         <item>com.google.android.gms</item>
     </string-array>
 

--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -1718,6 +1718,8 @@
         <item>com.android.location.fused</item>
         <!-- microG unifiednlp location provider (standalone) -->
         <item>org.microg.nlp</item>
+	<!-- The (faked) microg fused location provider (a free reimplementation) -->
+        <item>com.google.android.gms</item>
     </string-array>
 
     <!-- This string array can be overriden to enable test location providers initially. -->


### PR DESCRIPTION
Per [the microG patch set](https://github.com/microg/android_packages_apps_GmsCore/blob/master/patches/android_frameworks_base-P.patch#L27-L28).

Without this, only the GAPPS variant of UnifiedNLP works properly. If you install the no-GAPPS version of UnifedNLP, microG's self-check reports that the ROM doesn't support UnifiedNLP.