### PR TITLE
base: Make vendor mismatch message optional

### DIFF
--- a/core/res/res/values/rr_config.xml
+++ b/core/res/res/values/rr_config.xml
@@ -212,4 +212,7 @@
     </string-array>
 
     <bool name="disable_fod_night_light">false</bool>
+
+    <!-- Whether or not we should show vendor mismatch message -->
+    <bool name="config_show_vendor_mismatch_message">false</bool>
 </resources>

--- a/core/res/res/values/rr_symbols.xml
+++ b/core/res/res/values/rr_symbols.xml
@@ -277,4 +277,7 @@
     <!-- Device keyhandlers -->
   <java-symbol type="color" name="gradient_device_default" />
 
+    <!-- Whether or not we should show vendor mismatch message -->
+    <java-symbol type="bool" name="config_show_vendor_mismatch_message" />
+
 </resources>

--- a/services/core/java/com/android/server/wm/ActivityTaskManagerService.java
+++ b/services/core/java/com/android/server/wm/ActivityTaskManagerService.java
@@ -6545,7 +6545,9 @@ public class ActivityTaskManagerService extends IActivityTaskManager.Stub {
                 if (!Build.isBuildConsistent()) {
                     Slog.e(TAG, "Build fingerprint is not consistent, warning user");
                     mUiHandler.post(() -> {
-                        if (mShowDialogs) {
+                        boolean mShowVendorMismatch = Resources.getSystem().getBoolean(
+                                R.bool.config_show_vendor_mismatch_message);
+                        if (mShowDialogs && mShowVendorMismatch) {
                             AlertDialog d = new BaseErrorDialog(mUiContext);
                             d.getWindow().setType(WindowManager.LayoutParams.TYPE_SYSTEM_ERROR);
                             d.setCancelable(false);


### PR DESCRIPTION
Thanks to @ZeNiXxX for the idea

For Non Treble devices when build fingerprint is modified, At the initial boot Android throws up the error vendor image does not match with the system.
Setting to false by default, as no one would like to see that message.