### PR TITLE
base: Add support to disable h265 on screenrecorder

### DIFF
--- a/packages/SystemUI/res/values/rr_config.xml
+++ b/packages/SystemUI/res/values/rr_config.xml
@@ -60,4 +60,7 @@
 
     <!-- Asus stitch editor component name -->
     <string name="config_stitchEditor">com.asus.stitchimage/com.asus.stitchimage.editor.ScreenshotEditorActivity</string>
+
+    <!-- Allow devices to enforce the H265 encoder for screen recordings -->
+    <bool name="config_useNewScreenRecEncoder">true</bool>
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/screenrecord/RecordingService.java
+++ b/packages/SystemUI/src/com/android/systemui/screenrecord/RecordingService.java
@@ -301,6 +301,9 @@ public class RecordingService extends Service {
                 e.printStackTrace();
             }
 
+            // Check if the device allows to use h265 for lighter recordings
+            boolean useH265 = getResources().getBoolean(R.bool.config_useNewScreenRecEncoder);
+
             // Set initial resources
             DisplayMetrics metrics = new DisplayMetrics();
             mWindowManager.getDefaultDisplay().getRealMetrics(metrics);
@@ -349,6 +352,7 @@ public class RecordingService extends Service {
             }
 
             // Reving up those recorders
+            boolean useOldEncoder = mIsLowRamEnabled || !useH265;
             switch (mAudioSourceOpt) {
                 case 1:
                     mVideoBufferInfo = new MediaCodec.BufferInfo();
@@ -357,7 +361,7 @@ public class RecordingService extends Service {
                         AUDIO_CHANNEL_TYPE,
                         AudioFormat.ENCODING_PCM_16BIT);
                     // Preparing video encoder
-                    MediaFormat videoFormat = MediaFormat.createVideoFormat(mIsLowRamEnabled ? "video/avc" : "video/hevc", screenWidth, screenHeight);
+                    MediaFormat videoFormat = MediaFormat.createVideoFormat(useOldEncoder ? "video/avc" : "video/hevc", screenWidth, screenHeight);
                     videoFormat.setInteger(MediaFormat.KEY_COLOR_FORMAT,
                         MediaCodecInfo.CodecCapabilities.COLOR_FormatSurface);
                     videoFormat.setInteger(MediaFormat.KEY_BIT_RATE, VIDEO_BIT_RATE);
@@ -366,7 +370,7 @@ public class RecordingService extends Service {
                     videoFormat.setInteger(MediaFormat.KEY_REPEAT_PREVIOUS_FRAME_AFTER, 1000000 / VIDEO_FRAME_RATE);
                     videoFormat.setInteger(MediaFormat.KEY_CHANNEL_COUNT, 1);
                     videoFormat.setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, 1);
-                    mVideoEncoder = MediaCodec.createEncoderByType(mIsLowRamEnabled ? "video/avc" : "video/hevc");
+                    mVideoEncoder = MediaCodec.createEncoderByType(useOldEncoder ? "video/avc" : "video/hevc");
                     mVideoEncoder.configure(videoFormat, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE);
                     // Preparing audio encoder
                     MediaFormat mAudioFormat = MediaFormat.createAudioFormat("audio/mp4a-latm", AUDIO_SAMPLE_RATE, TOTAL_NUM_TRACKS);
@@ -403,7 +407,7 @@ public class RecordingService extends Service {
                     if (mAudioSourceOpt == 2) mMediaRecorder.setAudioSource(MediaRecorder.AudioSource.MIC);
                     mMediaRecorder.setVideoSource(MediaRecorder.VideoSource.SURFACE);
                     mMediaRecorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4);
-                    mMediaRecorder.setVideoEncoder(mIsLowRamEnabled ? MediaRecorder.VideoEncoder.H264 : MediaRecorder.VideoEncoder.HEVC);
+                    mMediaRecorder.setVideoEncoder(useOldEncoder ? MediaRecorder.VideoEncoder.H264 : MediaRecorder.VideoEncoder.HEVC);
                     mMediaRecorder.setVideoSize(screenWidth, screenHeight);
                     mMediaRecorder.setVideoFrameRate(VIDEO_FRAME_RATE);
                     mMediaRecorder.setVideoEncodingBitRate(VIDEO_BIT_RATE);


### PR DESCRIPTION
Some legacy users might not have the codecs to record/play the final recordings, so let's allow them to
overlay config_useNewScreenRecEncoder in case they need to disable that.

Current set to true, as we want to use it as default.

Change-Id: I4e560af8b36f704aaa4f0df5243d590a5448fc5c
Signed-off-by: adi153 <singhmanohar6699@gmail.com>