### PR TITLE
DozeSensors: only use proximity sensor if supported

### DIFF
--- a/packages/SystemUI/res/values/lineage_config.xml
+++ b/packages/SystemUI/res/values/lineage_config.xml
@@ -36,4 +36,7 @@
          the sensor embedded in the power key and listening all the time
          causes a poor experience. -->
     <bool name="config_fingerprintWakeAndUnlock">true</bool>
+
+    <!-- Whether usage of the proximity sensor during doze is supported -->
+    <bool name="doze_proximity_sensor_supported">true</bool>
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/doze/DozeSensors.java
+++ b/packages/SystemUI/src/com/android/systemui/doze/DozeSensors.java
@@ -49,6 +49,7 @@ import com.android.systemui.util.AlarmTimeout;
 import com.android.systemui.util.AsyncSensorManager;
 import com.android.systemui.util.ProximitySensor;
 import com.android.systemui.util.wakelock.WakeLock;
+import com.android.systemui.R;
 
 import java.io.PrintWriter;
 import java.util.List;
@@ -146,7 +147,12 @@ public class DozeSensors {
                         false /* touchscreen */, mConfig.getWakeLockScreenDebounce()),
         };
 
-        mProxSensor = new ProxSensor(policy);
+        if (context.getResources().getBoolean(R.bool.doze_proximity_sensor_supported)) {
+            mProxSensor = new ProxSensor(policy);
+        } else {
+            mProxSensor = null;
+        }
+
         mCallback = callback;
     }
 
@@ -236,7 +242,9 @@ public class DozeSensors {
     }
 
     public void setProxListening(boolean listen) {
-        mProxSensor.setRequested(listen);
+        if (mProxSensor != null) {
+            mProxSensor.setRequested(listen);
+        }
     }
 
     private final ContentObserver mSettingsObserver = new ContentObserver(mHandler) {
@@ -269,14 +277,15 @@ public class DozeSensors {
         for (TriggerSensor s : mSensors) {
             pw.print("  Sensor: "); pw.println(s.toString());
         }
-        pw.print("  ProxSensor: "); pw.println(mProxSensor.toString());
+        pw.print("  ProxSensor: "); pw.println(mProxSensor == null
+                ? "null" : mProxSensor.toString());
     }
 
     /**
      * @return true if prox is currently far, false if near or null if unknown.
      */
     public Boolean isProximityCurrentlyFar() {
-        return mProxSensor.mCurrentlyFar;
+        return mProxSensor == null ? null : mProxSensor.mCurrentlyFar;
     }
 
     private class ProxSensor implements SensorEventListener {


### PR DESCRIPTION
On msm-4.14 devices, when the proximity sensor is in use,
the smp2p-sleepstate IRQ is fired multiple times a second,
with each one holding a 200ms wakelock.
This is probably a bug in the DSP firmware.
To fix this, avoid using the proximity sensor in doze mode,
because sleep is preferred to turning off the screen.

Change-Id: I57750afd77267abdc49780f70636626d20e666ad