### PR TITLE
[RESTRICT AUTOMERGE] Fix OOB write in noteAtomLogged

### DIFF
--- a/cmds/statsd/src/guardrail/StatsdStats.cpp
+++ b/cmds/statsd/src/guardrail/StatsdStats.cpp
@@ -449,9 +449,12 @@ void StatsdStats::notePullExceedMaxDelay(int pullAtomId) {
 void StatsdStats::noteAtomLogged(int atomId, int32_t timeSec) {
     lock_guard<std::mutex> lock(mLock);
 
-    if (atomId <= android::util::kMaxPushedAtomId) {
+    if (atomId >= 0 && atomId <= android::util::kMaxPushedAtomId) {
         mPushedAtomStats[atomId]++;
     } else {
+        if (atomId < 0) {
+            android_errorWriteLog(0x534e4554, "187957589");
+        }
         if (mNonPlatformPushedAtomStats.size() < kMaxNonPlatformPushedAtoms) {
             mNonPlatformPushedAtomStats[atomId]++;
         }


### PR DESCRIPTION
It's possible for bad atoms to have negative atom ids. This results in
an OOB write when we note that the atom was logged. This adds a
validation check on the logging.

Also added safetynet logging for negative atoms

Bug: 187957589
Test: POC in bug no longer led to the OOB write & crash
Test: checked event log for safetynet logging
Change-Id: I8a6b094c94309d7b02430fb860891ef814efb426
(cherry picked from commit b13b741a94a3d1fc85277de22644c62778bd3adc)